### PR TITLE
Increase the maximum of neurons number

### DIFF
--- a/playground.ts
+++ b/playground.ts
@@ -52,6 +52,7 @@ const RECT_SIZE = 30;
 const NUM_SAMPLES_CLASSIFY = 500;
 const NUM_SAMPLES_REGRESS = 1200;
 const DENSITY = 100;
+const NUM_NEURONS_MAX = 50;
 
 interface InputFeature {
   f: (x: number, y: number) => number;
@@ -599,7 +600,7 @@ function addPlusMinusControl(x: number, layerIdx: number) {
       .attr("class", "mdl-button mdl-js-button mdl-button--icon")
       .on("click", () => {
         let numNeurons = state.networkShape[i];
-        if (numNeurons >= 8) {
+        if (numNeurons >= NUM_NEURONS_MAX) {
           return;
         }
         state.networkShape[i]++;


### PR DESCRIPTION
To learn the spiral, neurons number and samples number are important.
Some people confused that they cannot learn the spiral by 1 hidden layer and without modifying the input.

I changed from
- Maximum neurons number: 8
- Samples number: Fixed

to
- Maximum neurons number: 50
- Samples number: Can change from the user interface

With this modification, I can learn the spiral with 1 hidden layer, 15 neurons, and 3500 samples.

I will split this maximum neurons number pull request and the samples number pull request.

Please merge!

![1](https://cloud.githubusercontent.com/assets/194666/14520992/3796cd2c-0262-11e6-8f05-18078e3a12db.png)
