### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ To produce a minified javascript file for production, run `npm run build`.
 To push to production: `git subtree push --prefix dist origin gh-pages`.
 
 This is not an official Google product.
+
+## Cloud Development
+
+Create a free development environment for this neural network project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Tensorflow Playground via `Run > Start Tensorflow Playground` and access your site via `Preview > 8080`.

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Tensorflow Playground project on Nitrous.
+
+## Running the Tensorflow Playground  server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Tensorflow Playground via "Run > Start Tensorflow Playground"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 8080".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "nodejs",
+  "ports": [8080],
+  "name": "Tensorflow Playground",
+  "description": "Play with neural networks!",
+  "scripts": {
+    "post-create": "echo 'running npm install - this might take awhile...' && npm install",
+    "Start Tensorflow PlayGround": "cd ~/code/playground && npm run serve"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.
