### PR TITLE
removes deprecation warning

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
   "ambientDependencies": {
-    "d3": "registry:dt/d3#0.0.0+20160315011939"
+    "d3": "registry:dt/d3#0.0.0+20160514171929"
   }
 }


### PR DESCRIPTION
The following deprecation warning is issued when `npm run prep` is run for the first time. 

``` shell
typings WARN deprecated 5/14/2016, 10:19:29 AM: "registry:dt/d3#0.0.0+20160315011939" has been deprecated
```

This PR fixes the issue. 
