### PR TITLE
More activation functions

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1,2 +1,1792 @@
-!function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a="function"==typeof require&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}for(var i="function"==typeof require&&require,o=0;o<r.length;o++)s(r[o]);return s}({1:[function(require,module,exports){"use strict";function shuffle(array){for(var counter=array.length,temp=0,index=0;counter>0;)index=Math.floor(Math.random()*counter),counter--,temp=array[counter],array[counter]=array[index],array[index]=temp}function classifyTwoGaussData(numSamples,noise){function genGauss(cx,cy,label){for(var i=0;numSamples/2>i;i++){var x=normalRandom(cx,variance),y=normalRandom(cy,variance);points.push({x:x,y:y,label:label})}}var points=[],varianceScale=d3.scale.linear().domain([0,.5]).range([.5,4]),variance=varianceScale(noise);return genGauss(2,2,1),genGauss(-2,-2,-1),points}function regressPlane(numSamples,noise){for(var radius=6,labelScale=d3.scale.linear().domain([-10,10]).range([-1,1]),getLabel=function(x,y){return labelScale(x+y)},points=[],i=0;numSamples>i;i++){var x=randUniform(-radius,radius),y=randUniform(-radius,radius),noiseX=randUniform(-radius,radius)*noise,noiseY=randUniform(-radius,radius)*noise,label=getLabel(x+noiseX,y+noiseY);points.push({x:x,y:y,label:label})}return points}function regressGaussian(numSamples,noise){function getLabel(x,y){var label=0;return gaussians.forEach(function(_a){var cx=_a[0],cy=_a[1],sign=_a[2],newLabel=sign*labelScale(dist({x:x,y:y},{x:cx,y:cy}));Math.abs(newLabel)>Math.abs(label)&&(label=newLabel)}),label}for(var points=[],labelScale=d3.scale.linear().domain([0,2]).range([1,0]).clamp(!0),gaussians=[[-4,2.5,1],[0,2.5,-1],[4,2.5,1],[-4,-2.5,-1],[0,-2.5,1],[4,-2.5,-1]],radius=6,i=0;numSamples>i;i++){var x=randUniform(-radius,radius),y=randUniform(-radius,radius),noiseX=randUniform(-radius,radius)*noise,noiseY=randUniform(-radius,radius)*noise,label=getLabel(x+noiseX,y+noiseY);points.push({x:x,y:y,label:label})}return points}function classifySpiralData(numSamples,noise){function genSpiral(deltaT,label){for(var i=0;n>i;i++){var r=i/n*5,t=1.75*i/n*2*Math.PI+deltaT,x=r*Math.sin(t)+randUniform(-1,1)*noise,y=r*Math.cos(t)+randUniform(-1,1)*noise;points.push({x:x,y:y,label:label})}}var points=[],n=numSamples/2;return genSpiral(0,1),genSpiral(Math.PI,-1),points}function classifyCircleData(numSamples,noise){function getCircleLabel(p,center){return dist(p,center)<.5*radius?1:-1}for(var points=[],radius=5,i=0;numSamples/2>i;i++){var r=randUniform(0,.5*radius),angle=randUniform(0,2*Math.PI),x=r*Math.sin(angle),y=r*Math.cos(angle),noiseX=randUniform(-radius,radius)*noise,noiseY=randUniform(-radius,radius)*noise,label=getCircleLabel({x:x+noiseX,y:y+noiseY},{x:0,y:0});points.push({x:x,y:y,label:label})}for(var i=0;numSamples/2>i;i++){var r=randUniform(.7*radius,radius),angle=randUniform(0,2*Math.PI),x=r*Math.sin(angle),y=r*Math.cos(angle),noiseX=randUniform(-radius,radius)*noise,noiseY=randUniform(-radius,radius)*noise,label=getCircleLabel({x:x+noiseX,y:y+noiseY},{x:0,y:0});points.push({x:x,y:y,label:label})}return points}function classifyXORData(numSamples,noise){function getXORLabel(p){return p.x*p.y>=0?1:-1}for(var points=[],i=0;numSamples>i;i++){var x=randUniform(-5,5),padding=.3;x+=x>0?padding:-padding;var y=randUniform(-5,5);y+=y>0?padding:-padding;var noiseX=randUniform(-5,5)*noise,noiseY=randUniform(-5,5)*noise,label=getXORLabel({x:x+noiseX,y:y+noiseY});points.push({x:x,y:y,label:label})}return points}function randUniform(a,b){return Math.random()*(b-a)+a}function normalRandom(mean,variance){void 0===mean&&(mean=0),void 0===variance&&(variance=1);var v1,v2,s;do v1=2*Math.random()-1,v2=2*Math.random()-1,s=v1*v1+v2*v2;while(s>1);var result=Math.sqrt(-2*Math.log(s)/s)*v1;return mean+Math.sqrt(variance)*result}function dist(a,b){var dx=a.x-b.x,dy=a.y-b.y;return Math.sqrt(dx*dx+dy*dy)}exports.shuffle=shuffle,exports.classifyTwoGaussData=classifyTwoGaussData,exports.regressPlane=regressPlane,exports.regressGaussian=regressGaussian,exports.classifySpiralData=classifySpiralData,exports.classifyCircleData=classifyCircleData,exports.classifyXORData=classifyXORData},{}],2:[function(require,module,exports){"use strict";function reduceMatrix(matrix,factor){if(matrix.length!==matrix[0].length)throw new Error("The provided matrix must be a square matrix");if(matrix.length%factor!==0)throw new Error("The width/height of the matrix must be divisible by the reduction factor");for(var result=new Array(matrix.length/factor),i=0;i<matrix.length;i+=factor){result[i/factor]=new Array(matrix.length/factor);for(var j=0;j<matrix.length;j+=factor){for(var avg=0,k=0;factor>k;k++)for(var l=0;factor>l;l++)avg+=matrix[i+k][j+l];avg/=factor*factor,result[i/factor][j/factor]=avg}}return result}var NUM_SHADES=30,HeatMap=function(){function HeatMap(width,numSamples,xDomain,yDomain,container,userSettings){this.settings={showAxes:!1,noSvg:!1},this.numSamples=numSamples;var height=width,padding=userSettings.showAxes?20:0;if(null!=userSettings)for(var prop in userSettings)this.settings[prop]=userSettings[prop];this.xScale=d3.scale.linear().domain(xDomain).range([0,width-2*padding]),this.yScale=d3.scale.linear().domain(yDomain).range([height-2*padding,0]);var tmpScale=d3.scale.linear().domain([0,.5,1]).range(["#f59322","#e8eaeb","#0877bd"]).clamp(!0),colors=d3.range(0,1+1e-9,1/NUM_SHADES).map(function(a){return tmpScale(a)});if(this.color=d3.scale.quantize().domain([-1,1]).range(colors),container=container.append("div").style({width:width+"px",height:height+"px",position:"relative",top:"-"+padding+"px",left:"-"+padding+"px"}),this.canvas=container.append("canvas").attr("width",numSamples).attr("height",numSamples).style("width",width-2*padding+"px").style("height",height-2*padding+"px").style("position","absolute").style("top",padding+"px").style("left",padding+"px"),this.settings.noSvg||(this.svg=container.append("svg").attr({width:width,height:height}).style({position:"absolute",left:"0",top:"0"}).append("g").attr("transform","translate("+padding+","+padding+")"),this.svg.append("g").attr("class","train"),this.svg.append("g").attr("class","test")),this.settings.showAxes){var xAxis=d3.svg.axis().scale(this.xScale).orient("bottom"),yAxis=d3.svg.axis().scale(this.yScale).orient("right");this.svg.append("g").attr("class","x axis").attr("transform","translate(0,"+(height-2*padding)+")").call(xAxis),this.svg.append("g").attr("class","y axis").attr("transform","translate("+(width-2*padding)+",0)").call(yAxis)}}return HeatMap.prototype.updateTestPoints=function(points){if(this.settings.noSvg)throw Error("Can't add points since noSvg=true");this.updateCircles(this.svg.select("g.test"),points)},HeatMap.prototype.updatePoints=function(points){if(this.settings.noSvg)throw Error("Can't add points since noSvg=true");this.updateCircles(this.svg.select("g.train"),points)},HeatMap.prototype.updateBackground=function(data,discretize){var dx=data[0].length,dy=data.length;if(dx!==this.numSamples||dy!==this.numSamples)throw new Error("The provided data matrix must be of size numSamples X numSamples");for(var context=this.canvas.node().getContext("2d"),image=context.createImageData(dx,dy),y=0,p=-1;dy>y;++y)for(var x=0;dx>x;++x){var value=data[x][y];discretize&&(value=value>=0?1:-1);var c=d3.rgb(this.color(value));image.data[++p]=c.r,image.data[++p]=c.g,image.data[++p]=c.b,image.data[++p]=160}context.putImageData(image,0,0)},HeatMap.prototype.updateCircles=function(container,points){var _this=this,xDomain=this.xScale.domain(),yDomain=this.yScale.domain();points=points.filter(function(p){return p.x>=xDomain[0]&&p.x<=xDomain[1]&&p.y>=yDomain[0]&&p.y<=yDomain[1]});var selection=container.selectAll("circle").data(points);selection.enter().append("circle").attr("r",3),selection.attr({cx:function(d){return _this.xScale(d.x)},cy:function(d){return _this.yScale(d.y)}}).style("fill",function(d){return _this.color(d.label)}),selection.exit().remove()},HeatMap}();exports.HeatMap=HeatMap,exports.reduceMatrix=reduceMatrix},{}],3:[function(require,module,exports){"use strict";var AppendingLineChart=function(){function AppendingLineChart(container,lineColors){this.data=[],this.minY=Number.MAX_VALUE,this.maxY=Number.MIN_VALUE,this.lineColors=lineColors,this.numLines=lineColors.length;var node=container.node(),totalWidth=node.offsetWidth,totalHeight=node.offsetHeight,margin={top:2,right:0,bottom:2,left:2},width=totalWidth-margin.left-margin.right,height=totalHeight-margin.top-margin.bottom;this.xScale=d3.scale.linear().domain([0,0]).range([0,width]),this.yScale=d3.scale.linear().domain([0,0]).range([height,0]),this.svg=container.append("svg").attr("width",width+margin.left+margin.right).attr("height",height+margin.top+margin.bottom).append("g").attr("transform","translate("+margin.left+","+margin.top+")"),this.paths=new Array(this.numLines);for(var i=0;i<this.numLines;i++)this.paths[i]=this.svg.append("path").attr("class","line").style({fill:"none",stroke:lineColors[i],"stroke-width":"1.5px"})}return AppendingLineChart.prototype.reset=function(){this.data=[],this.redraw(),this.minY=Number.MAX_VALUE,this.maxY=Number.MIN_VALUE},AppendingLineChart.prototype.addDataPoint=function(dataPoint){var _this=this;if(dataPoint.length!==this.numLines)throw Error("Length of dataPoint must equal number of lines");dataPoint.forEach(function(y){_this.minY=Math.min(_this.minY,y),_this.maxY=Math.max(_this.maxY,y)}),this.data.push({x:this.data.length+1,y:dataPoint}),this.redraw()},AppendingLineChart.prototype.redraw=function(){var _this=this;this.xScale.domain([1,this.data.length]),this.yScale.domain([this.minY,this.maxY]);for(var getPathMap=function(lineIndex){return d3.svg.line().x(function(d){return _this.xScale(d.x)}).y(function(d){return _this.yScale(d.y[lineIndex])})},i=0;i<this.numLines;i++)this.paths[i].datum(this.data).attr("d",getPathMap(i))},AppendingLineChart}();exports.AppendingLineChart=AppendingLineChart},{}],4:[function(require,module,exports){"use strict";function buildNetwork(networkShape,activation,outputActivation,regularization,inputIds){for(var numLayers=networkShape.length,id=1,network=[],layerIdx=0;numLayers>layerIdx;layerIdx++){var isOutputLayer=layerIdx===numLayers-1,isInputLayer=0===layerIdx,currentLayer=[];network.push(currentLayer);for(var numNodes=networkShape[layerIdx],i=0;numNodes>i;i++){var nodeId=id.toString();isInputLayer?nodeId=inputIds[i]:id++;var node=new Node(nodeId,isOutputLayer?outputActivation:activation);if(currentLayer.push(node),layerIdx>=1)for(var j=0;j<network[layerIdx-1].length;j++){var prevNode=network[layerIdx-1][j],link=new Link(prevNode,node,regularization);prevNode.outputs.push(link),node.inputLinks.push(link)}}}return network}function forwardProp(network,inputs){var inputLayer=network[0];if(inputs.length!==inputLayer.length)throw new Error("The number of inputs must match the number of nodes in the input layer");for(var i=0;i<inputLayer.length;i++){var node=inputLayer[i];node.output=inputs[i]}for(var layerIdx=1;layerIdx<network.length;layerIdx++)for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++){var node=currentLayer[i];node.updateOutput()}return network[network.length-1][0].output}function backProp(network,target,errorFunc){var outputNode=network[network.length-1][0];outputNode.outputDer=errorFunc.der(outputNode.output,target);for(var layerIdx=network.length-1;layerIdx>=1;layerIdx--){for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++){var node=currentLayer[i];node.inputDer=node.outputDer*node.activation.der(node.totalInput),node.accInputDer+=node.inputDer,node.numAccumulatedDers++}for(var i=0;i<currentLayer.length;i++)for(var node=currentLayer[i],j=0;j<node.inputLinks.length;j++){var link=node.inputLinks[j];link.errorDer=node.inputDer*link.source.output,link.accErrorDer+=link.errorDer,link.numAccumulatedDers++}if(1!==layerIdx)for(var prevLayer=network[layerIdx-1],i=0;i<prevLayer.length;i++){var node=prevLayer[i];node.outputDer=0;for(var j=0;j<node.outputs.length;j++){var output=node.outputs[j];node.outputDer+=output.weight*output.dest.inputDer}}}}function updateWeights(network,learningRate,regularizationRate){for(var layerIdx=1;layerIdx<network.length;layerIdx++)for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++){var node=currentLayer[i];node.numAccumulatedDers>0&&(node.bias-=learningRate*node.accInputDer/node.numAccumulatedDers,node.accInputDer=0,node.numAccumulatedDers=0);for(var j=0;j<node.inputLinks.length;j++){var link=node.inputLinks[j],regulDer=link.regularization?link.regularization.der(link.weight):0;link.numAccumulatedDers>0&&(link.weight-=learningRate/link.numAccumulatedDers*(link.accErrorDer+regularizationRate*regulDer),link.accErrorDer=0,link.numAccumulatedDers=0)}}}function forEachNode(network,ignoreInputs,accessor){for(var layerIdx=ignoreInputs?1:0;layerIdx<network.length;layerIdx++)for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++){var node=currentLayer[i];accessor(node)}}function getOutputNode(network){return network[network.length-1][0]}var Node=function(){function Node(id,activation){this.inputLinks=[],this.bias=.1,this.outputs=[],this.outputDer=0,this.inputDer=0,this.accInputDer=0,this.numAccumulatedDers=0,this.id=id,this.activation=activation}return Node.prototype.updateOutput=function(){this.totalInput=this.bias;for(var j=0;j<this.inputLinks.length;j++){var link=this.inputLinks[j];this.totalInput+=link.weight*link.source.output}return this.output=this.activation.output(this.totalInput),this.output},Node}();exports.Node=Node;var Errors=function(){function Errors(){}return Errors.SQUARE={error:function(output,target){return.5*Math.pow(output-target,2)},der:function(output,target){return output-target}},Errors}();exports.Errors=Errors,Math.tanh=Math.tanh||function(x){if(x===1/0)return 1;if(x===-(1/0))return-1;var e2x=Math.exp(2*x);return(e2x-1)/(e2x+1)};var Activations=function(){function Activations(){}return Activations.TANH={output:function(x){return Math.tanh(x)},der:function(x){var output=Activations.TANH.output(x);return 1-output*output}},Activations.RELU={output:function(x){return Math.max(0,x)},der:function(x){return 0>=x?0:1}},Activations.SIGMOID={output:function(x){return 1/(1+Math.exp(-x))},der:function(x){var output=Activations.SIGMOID.output(x);return output*(1-output)}},Activations.LINEAR={output:function(x){return x},der:function(x){return 1}},Activations}();exports.Activations=Activations;var RegularizationFunction=function(){function RegularizationFunction(){}return RegularizationFunction.L1={output:function(w){return Math.abs(w)},der:function(w){return 0>w?-1:1}},RegularizationFunction.L2={output:function(w){return.5*w*w},der:function(w){return w}},RegularizationFunction}();exports.RegularizationFunction=RegularizationFunction;var Link=function(){function Link(source,dest,regularization){this.weight=Math.random()-.5,this.errorDer=0,this.accErrorDer=0,this.numAccumulatedDers=0,this.id=source.id+"-"+dest.id,this.source=source,this.dest=dest,this.regularization=regularization}return Link}();exports.Link=Link,exports.buildNetwork=buildNetwork,exports.forwardProp=forwardProp,exports.backProp=backProp,exports.updateWeights=updateWeights,exports.forEachNode=forEachNode,exports.getOutputNode=getOutputNode},{}],5:[function(require,module,exports){"use strict";function scrollTween(offset){return function(){var i=d3.interpolateNumber(window.pageYOffset||document.documentElement.scrollTop,offset);return function(t){scrollTo(0,i(t))}}}function makeGUI(){d3.select("#reset-button").on("click",function(){reset(),d3.select("#play-pause-button")}),d3.select("#play-pause-button").on("click",function(){player.playOrPause()}),player.onPlayPause(function(isPlaying){d3.select("#play-pause-button").classed("playing",isPlaying)}),d3.select("#next-step-button").on("click",function(){player.pause(),oneStep()}),d3.select("#data-regen-button").on("click",function(){generateData()});var dataThumbnails=d3.selectAll("canvas[data-dataset]");dataThumbnails.on("click",function(){var newDataset=state_1.datasets[this.dataset.dataset];newDataset!==state.dataset&&(state.dataset=newDataset,dataThumbnails.classed("selected",!1),d3.select(this).classed("selected",!0),generateData(),reset())});var datasetKey=state_1.getKeyFromValue(state_1.datasets,state.dataset);d3.select("canvas[data-dataset="+datasetKey+"]").classed("selected",!0);var regDataThumbnails=d3.selectAll("canvas[data-regDataset]");regDataThumbnails.on("click",function(){var newDataset=state_1.regDatasets[this.dataset.regdataset];newDataset!==state.regDataset&&(state.regDataset=newDataset,regDataThumbnails.classed("selected",!1),d3.select(this).classed("selected",!0),generateData(),reset())});var regDatasetKey=state_1.getKeyFromValue(state_1.regDatasets,state.regDataset);d3.select("canvas[data-regDataset="+regDatasetKey+"]").classed("selected",!0),d3.select("#add-layers").on("click",function(){state.numHiddenLayers>=6||(state.networkShape[state.numHiddenLayers]=2,state.numHiddenLayers++,reset())}),d3.select("#remove-layers").on("click",function(){state.numHiddenLayers<=0||(state.numHiddenLayers--,state.networkShape.splice(state.numHiddenLayers),reset())});var showTestData=d3.select("#show-test-data").on("change",function(){state.showTestData=this.checked,state.serialize(),heatMap.updateTestPoints(state.showTestData?testData:[])});showTestData.property("checked",state.showTestData);var discretize=d3.select("#discretize").on("change",function(){state.discretize=this.checked,state.serialize(),updateUI()});discretize.property("checked",state.discretize);var percTrain=d3.select("#percTrainData").on("input",function(){state.percTrainData=this.value,d3.select("label[for='percTrainData'] .value").text(this.value),generateData(),reset()});percTrain.property("value",state.percTrainData),d3.select("label[for='percTrainData'] .value").text(state.percTrainData);var noise=d3.select("#noise").on("input",function(){state.noise=this.value,d3.select("label[for='noise'] .value").text(this.value),generateData(),reset()});noise.property("value",state.noise),d3.select("label[for='noise'] .value").text(state.noise);var batchSize=d3.select("#batchSize").on("input",function(){state.batchSize=this.value,d3.select("label[for='batchSize'] .value").text(this.value),reset()});batchSize.property("value",state.batchSize),d3.select("label[for='batchSize'] .value").text(state.batchSize);var activationDropdown=d3.select("#activations").on("change",function(){state.activation=state_1.activations[this.value],reset()});activationDropdown.property("value",state_1.getKeyFromValue(state_1.activations,state.activation));var learningRate=d3.select("#learningRate").on("change",function(){state.learningRate=+this.value});learningRate.property("value",state.learningRate);var regularDropdown=d3.select("#regularizations").on("change",function(){state.regularization=state_1.regularizations[this.value],reset()});regularDropdown.property("value",state_1.getKeyFromValue(state_1.regularizations,state.regularization));var regularRate=d3.select("#regularRate").on("change",function(){state.regularizationRate=+this.value,reset()});regularRate.property("value",state.regularizationRate);var problem=d3.select("#problem").on("change",function(){state.problem=state_1.problems[this.value],generateData(),drawDatasetThumbnails(),reset()});problem.property("value",state_1.getKeyFromValue(state_1.problems,state.problem));var x=d3.scale.linear().domain([-1,1]).range([0,144]),xAxis=d3.svg.axis().scale(x).orient("bottom").tickValues([-1,0,1]).tickFormat(d3.format("d"));d3.select("#colormap g.core").append("g").attr("class","x axis").attr("transform","translate(0,10)").call(xAxis),window.addEventListener("resize",function(){var newWidth=document.querySelector("#main-part").getBoundingClientRect().width;newWidth!==mainWidth&&(mainWidth=newWidth,drawNetwork(network),updateUI(!0))})}function updateBiasesUI(network){nn.forEachNode(network,!0,function(node){d3.select("rect#bias-"+node.id).style("fill",colorScale(node.bias))})}function updateWeightsUI(network,container){for(var layerIdx=1;layerIdx<network.length;layerIdx++)for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++)for(var node=currentLayer[i],j=0;j<node.inputLinks.length;j++){var link=node.inputLinks[j];container.select("#link"+link.source.id+"-"+link.dest.id).style({"stroke-dashoffset":-iter/3,"stroke-width":linkWidthScale(Math.abs(link.weight)),stroke:colorScale(link.weight)}).datum(link)}}function drawNode(cx,cy,nodeId,isInput,container,node){var x=cx-RECT_SIZE/2,y=cy-RECT_SIZE/2,nodeGroup=container.append("g").attr({"class":"node",id:"node"+nodeId,transform:"translate("+x+","+y+")"});nodeGroup.append("rect").attr({x:0,y:0,width:RECT_SIZE,height:RECT_SIZE});var activeOrNotClass=state[nodeId]?"active":"inactive";if(isInput){var label=null!=INPUTS[nodeId].label?INPUTS[nodeId].label:nodeId,text=nodeGroup.append("text").attr({"class":"main-label",x:-10,y:RECT_SIZE/2,"text-anchor":"end"});if(/[_^]/.test(label)){for(var myRe=/(.*?)([_^])(.)/g,myArray=void 0,lastIndex=void 0;null!==(myArray=myRe.exec(label));){lastIndex=myRe.lastIndex;var prefix=myArray[1],sep=myArray[2],suffix=myArray[3];prefix&&text.append("tspan").text(prefix),text.append("tspan").attr("baseline-shift","_"==sep?"sub":"super").style("font-size","9px").text(suffix)}label.substring(lastIndex)&&text.append("tspan").text(label.substring(lastIndex))}else text.append("tspan").text(label);nodeGroup.classed(activeOrNotClass,!0)}isInput||nodeGroup.append("rect").attr({id:"bias-"+nodeId,x:-BIAS_SIZE-2,y:RECT_SIZE-BIAS_SIZE+3,width:BIAS_SIZE,height:BIAS_SIZE}).on("mouseenter",function(){updateHoverCard(HoverType.BIAS,node,d3.mouse(container.node()))}).on("mouseleave",function(){updateHoverCard(null)});var div=d3.select("#network").insert("div",":first-child").attr({id:"canvas-"+nodeId,"class":"canvas"}).style({position:"absolute",left:x+3+"px",top:y+3+"px"}).on("mouseenter",function(){selectedNodeId=nodeId,div.classed("hovered",!0),nodeGroup.classed("hovered",!0),updateDecisionBoundary(network,!1),heatMap.updateBackground(boundary[nodeId],state.discretize)}).on("mouseleave",function(){selectedNodeId=null,div.classed("hovered",!1),nodeGroup.classed("hovered",!1),updateDecisionBoundary(network,!1),heatMap.updateBackground(boundary[nn.getOutputNode(network).id],state.discretize)});isInput&&(div.on("click",function(){state[nodeId]=!state[nodeId],reset()}),div.style("cursor","pointer")),isInput&&div.classed(activeOrNotClass,!0);var nodeHeatMap=new heatmap_1.HeatMap(RECT_SIZE,DENSITY/10,xDomain,xDomain,div,{noSvg:!0});div.datum({heatmap:nodeHeatMap,id:nodeId})}function drawNetwork(network){var svg=d3.select("#svg");svg.select("g.core").remove(),d3.select("#network").selectAll("div.canvas").remove(),d3.select("#network").selectAll("div.plus-minus-neurons").remove();var padding=3,co=d3.select(".column.output").node(),cf=d3.select(".column.features").node(),width=co.offsetLeft-cf.offsetLeft;svg.attr("width",width);var node2coord={},container=svg.append("g").classed("core",!0).attr("transform","translate("+padding+","+padding+")"),numLayers=network.length,featureWidth=118,layerScale=d3.scale.ordinal().domain(d3.range(1,numLayers-1)).rangePoints([featureWidth,width-RECT_SIZE],.7),nodeIndexScale=function(nodeIndex){return nodeIndex*(RECT_SIZE+25)},calloutThumb=d3.select(".callout.thumbnail").style("display","none"),calloutWeights=d3.select(".callout.weights").style("display","none"),idWithCallout=null,targetIdWithCallout=null,cx=RECT_SIZE/2+50,nodeIds=Object.keys(INPUTS),maxY=nodeIndexScale(nodeIds.length);nodeIds.forEach(function(nodeId,i){var cy=nodeIndexScale(i)+RECT_SIZE/2;node2coord[nodeId]={cx:cx,cy:cy},drawNode(cx,cy,nodeId,!0,container)});for(var layerIdx=1;numLayers-1>layerIdx;layerIdx++){var numNodes=network[layerIdx].length,cx_1=layerScale(layerIdx)+RECT_SIZE/2;maxY=Math.max(maxY,nodeIndexScale(numNodes)),addPlusMinusControl(layerScale(layerIdx),layerIdx);for(var i=0;numNodes>i;i++){var node_1=network[layerIdx][i],cy_1=nodeIndexScale(i)+RECT_SIZE/2;node2coord[node_1.id]={cx:cx_1,cy:cy_1},drawNode(cx_1,cy_1,node_1.id,!1,container,node_1);var numNodes_1=network[layerIdx].length,nextNumNodes=network[layerIdx+1].length;null==idWithCallout&&i===numNodes_1-1&&numNodes_1>=nextNumNodes&&(calloutThumb.style({display:null,top:23+cy_1+"px",left:cx_1+"px"}),idWithCallout=node_1.id);for(var j=0;j<node_1.inputLinks.length;j++){var link=node_1.inputLinks[j],path=drawLink(link,node2coord,network,container,0===j,j,node_1.inputLinks.length).node(),prevLayer=network[layerIdx-1],lastNodePrevLayer=prevLayer[prevLayer.length-1];if(null==targetIdWithCallout&&i===numNodes_1-1&&link.source.id===lastNodePrevLayer.id&&(link.source.id!==idWithCallout||5>=numLayers)&&link.dest.id!==idWithCallout&&prevLayer.length>=numNodes_1){var midPoint=path.getPointAtLength(.7*path.getTotalLength());calloutWeights.style({display:null,top:midPoint.y+5+"px",left:midPoint.x+3+"px"}),targetIdWithCallout=link.dest.id}}}}cx=width+RECT_SIZE/2;var node=network[numLayers-1][0],cy=nodeIndexScale(0)+RECT_SIZE/2;node2coord[node.id]={cx:cx,cy:cy};for(var i=0;i<node.inputLinks.length;i++){var link=node.inputLinks[i];drawLink(link,node2coord,network,container,0===i,i,node.inputLinks.length)}svg.attr("height",maxY);var height=Math.max(getRelativeHeight(calloutThumb),getRelativeHeight(calloutWeights),getRelativeHeight(d3.select("#network")));d3.select(".column.features").style("height",height+"px")}function getRelativeHeight(selection){var node=selection.node();return node.offsetHeight+node.offsetTop}function addPlusMinusControl(x,layerIdx){var div=d3.select("#network").append("div").classed("plus-minus-neurons",!0).style("left",x-10+"px"),i=layerIdx-1,firstRow=div.append("div").attr("class","ui-numNodes"+layerIdx);firstRow.append("button").attr("class","mdl-button mdl-js-button mdl-button--icon").on("click",function(){var numNeurons=state.networkShape[i];numNeurons>=8||(state.networkShape[i]++,reset())}).append("i").attr("class","material-icons").text("add"),firstRow.append("button").attr("class","mdl-button mdl-js-button mdl-button--icon").on("click",function(){var numNeurons=state.networkShape[i];1>=numNeurons||(state.networkShape[i]--,reset())}).append("i").attr("class","material-icons").text("remove");var suffix=state.networkShape[i]>1?"s":"";div.append("div").text(state.networkShape[i]+" neuron"+suffix)}function updateHoverCard(type,nodeOrLink,coordinates){var hovercard=d3.select("#hovercard");if(null==type)return hovercard.style("display","none"),void d3.select("#svg").on("click",null);d3.select("#svg").on("click",function(){hovercard.select(".value").style("display","none");var input=hovercard.select("input");input.style("display",null),input.on("input",function(){null!=this.value&&""!==this.value&&(type==HoverType.WEIGHT?nodeOrLink.weight=+this.value:nodeOrLink.bias=+this.value,updateUI())}),input.on("keypress",function(){13==d3.event.keyCode&&updateHoverCard(type,nodeOrLink,coordinates)}),input.node().focus()});var value=type==HoverType.WEIGHT?nodeOrLink.weight:nodeOrLink.bias,name=type==HoverType.WEIGHT?"Weight":"Bias";hovercard.style({left:coordinates[0]+20+"px",top:coordinates[1]+"px",display:"block"}),hovercard.select(".type").text(name),hovercard.select(".value").style("display",null).text(value.toPrecision(2)),hovercard.select("input").property("value",value.toPrecision(2)).style("display","none")}function drawLink(input,node2coord,network,container,isFirst,index,length){var line=container.insert("path",":first-child"),source=node2coord[input.source.id],dest=node2coord[input.dest.id],datum={source:{y:source.cx+RECT_SIZE/2+2,x:source.cy},target:{y:dest.cx-RECT_SIZE/2,x:dest.cy+(index-(length-1)/2)/length*12}},diagonal=d3.svg.diagonal().projection(function(d){return[d.y,d.x]});return line.attr({"marker-start":"url(#markerArrow)","class":"link",id:"link"+input.source.id+"-"+input.dest.id,d:diagonal(datum,0)}),container.append("path").attr("d",diagonal(datum,0)).attr("class","link-hover").on("mouseenter",function(){updateHoverCard(HoverType.WEIGHT,input,d3.mouse(this))}).on("mouseleave",function(){updateHoverCard(null)}),line}function updateDecisionBoundary(network,firstTime){if(firstTime){boundary={},nn.forEachNode(network,!0,function(node){boundary[node.id]=new Array(DENSITY)});for(var nodeId in INPUTS)boundary[nodeId]=new Array(DENSITY)}var xScale=d3.scale.linear().domain([0,DENSITY-1]).range(xDomain),yScale=d3.scale.linear().domain([DENSITY-1,0]).range(xDomain),i=0,j=0;for(i=0;DENSITY>i;i++){if(firstTime){nn.forEachNode(network,!0,function(node){boundary[node.id][i]=new Array(DENSITY)});for(var nodeId in INPUTS)boundary[nodeId][i]=new Array(DENSITY)}for(j=0;DENSITY>j;j++){var x=xScale(i),y=yScale(j),input=constructInput(x,y);if(nn.forwardProp(network,input),nn.forEachNode(network,!0,function(node){boundary[node.id][i][j]=node.output}),firstTime)for(var nodeId in INPUTS)boundary[nodeId][i][j]=INPUTS[nodeId].f(x,y)}}}function getLoss(network,dataPoints){for(var loss=0,i=0;i<dataPoints.length;i++){var dataPoint=dataPoints[i],input=constructInput(dataPoint.x,dataPoint.y),output=nn.forwardProp(network,input);loss+=nn.Errors.SQUARE.error(output,dataPoint.label)}return loss/dataPoints.length}function updateUI(firstStep){function zeroPad(n){var pad="000000";return(pad+n).slice(-pad.length)}function addCommas(s){return s.replace(/\B(?=(\d{3})+(?!\d))/g,",")}function humanReadable(n){return n.toFixed(3)}void 0===firstStep&&(firstStep=!1),updateWeightsUI(network,d3.select("g.core")),updateBiasesUI(network),updateDecisionBoundary(network,firstStep);var selectedId=null!=selectedNodeId?selectedNodeId:nn.getOutputNode(network).id;heatMap.updateBackground(boundary[selectedId],state.discretize),d3.select("#network").selectAll("div.canvas").each(function(data){data.heatmap.updateBackground(heatmap_1.reduceMatrix(boundary[data.id],10),state.discretize)}),d3.select("#loss-train").text(humanReadable(lossTrain)),d3.select("#loss-test").text(humanReadable(lossTest)),d3.select("#iter-number").text(addCommas(zeroPad(iter))),lineChart.addDataPoint([lossTrain,lossTest])}function constructInputIds(){var result=[];for(var inputName in INPUTS)state[inputName]&&result.push(inputName);return result}function constructInput(x,y){var input=[];for(var inputName in INPUTS)state[inputName]&&input.push(INPUTS[inputName].f(x,y));return input}function oneStep(){iter++,trainData.forEach(function(point,i){var input=constructInput(point.x,point.y);nn.forwardProp(network,input),nn.backProp(network,point.label,nn.Errors.SQUARE),(i+1)%state.batchSize===0&&nn.updateWeights(network,state.learningRate,state.regularizationRate)}),lossTrain=getLoss(network,trainData),lossTest=getLoss(network,testData),updateUI()}function getOutputWeights(network){for(var weights=[],layerIdx=0;layerIdx<network.length-1;layerIdx++)for(var currentLayer=network[layerIdx],i=0;i<currentLayer.length;i++)for(var node=currentLayer[i],j=0;j<node.outputs.length;j++){var output=node.outputs[j];weights.push(output.weight)}return weights}function reset(){lineChart.reset(),state.serialize(),player.pause();var suffix=1!==state.numHiddenLayers?"s":"";d3.select("#layers-label").text("Hidden layer"+suffix),d3.select("#num-layers").text(state.numHiddenLayers),iter=0;var numInputs=constructInput(0,0).length,shape=[numInputs].concat(state.networkShape).concat([1]),outputActivation=state.problem==state_1.Problem.REGRESSION?nn.Activations.LINEAR:nn.Activations.TANH;network=nn.buildNetwork(shape,state.activation,outputActivation,state.regularization,constructInputIds()),lossTrain=getLoss(network,trainData),lossTest=getLoss(network,testData),drawNetwork(network),updateUI(!0)}function initTutorial(){if(null!=state.tutorial){d3.selectAll("article div.l--body").remove();var tutorial=d3.select("article").append("div").attr("class","l--body");
-d3.html("tutorials/"+state.tutorial+".html",function(err,htmlFragment){if(err)throw err;tutorial.node().appendChild(htmlFragment);var title=tutorial.select("title");title.size()&&(d3.select("header h1").style({"margin-top":"20px","margin-bottom":"20px"}).text(title.text()),document.title=title.text())})}}function drawDatasetThumbnails(){function renderThumbnail(canvas,dataGenerator){var w=100,h=100;canvas.setAttribute("width",w),canvas.setAttribute("height",h);var context=canvas.getContext("2d"),data=dataGenerator(200,0);data.forEach(function(d){context.fillStyle=colorScale(d.label),context.fillRect(w*(d.x+6)/12,h*(d.y+6)/12,4,4)}),d3.select(canvas.parentNode).style("display",null)}if(d3.selectAll(".dataset").style("display","none"),state.problem==state_1.Problem.CLASSIFICATION)for(var dataset in state_1.datasets){var canvas=document.querySelector("canvas[data-dataset="+dataset+"]"),dataGenerator=state_1.datasets[dataset];renderThumbnail(canvas,dataGenerator)}if(state.problem==state_1.Problem.REGRESSION)for(var regDataset in state_1.regDatasets){var canvas=document.querySelector("canvas[data-regDataset="+regDataset+"]"),dataGenerator=state_1.regDatasets[regDataset];renderThumbnail(canvas,dataGenerator)}}function hideControls(){var hiddenProps=state.getHiddenProps();hiddenProps.forEach(function(prop){var controls=d3.selectAll(".ui-"+prop);0==controls.size()&&console.warn("0 html elements found with class .ui-"+prop),controls.style("display","none")});var hideControls=d3.select(".hide-controls");HIDABLE_CONTROLS.forEach(function(_a){var text=_a[0],id=_a[1],label=hideControls.append("label").attr("class","mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect"),input=label.append("input").attr({type:"checkbox","class":"mdl-checkbox__input"});-1==hiddenProps.indexOf(id)&&input.attr("checked","true"),input.on("change",function(){state.setHideProperty(id,!this.checked),state.serialize(),d3.select(".hide-controls-link").attr("href",window.location.href)}),label.append("span").attr("class","mdl-checkbox__label label").text(text)}),d3.select(".hide-controls-link").attr("href",window.location.href)}function generateData(firstTime){void 0===firstTime&&(firstTime=!1),firstTime||(state.seed=Math.random().toFixed(5),state.serialize()),Math.seedrandom(state.seed);var numSamples=state.problem==state_1.Problem.REGRESSION?NUM_SAMPLES_REGRESS:NUM_SAMPLES_CLASSIFY,generator=state.problem==state_1.Problem.CLASSIFICATION?state.dataset:state.regDataset,data=generator(numSamples,state.noise/100);dataset_1.shuffle(data);var splitIndex=Math.floor(data.length*state.percTrainData/100);trainData=data.slice(0,splitIndex),testData=data.slice(splitIndex),heatMap.updatePoints(trainData),heatMap.updateTestPoints(state.showTestData?testData:[])}var mainWidth,nn=require("./nn"),heatmap_1=require("./heatmap"),state_1=require("./state"),dataset_1=require("./dataset"),linechart_1=require("./linechart");d3.select(".more button").on("click",function(){var position=800;d3.transition().duration(1e3).tween("scroll",scrollTween(position))});var HoverType,RECT_SIZE=30,BIAS_SIZE=5,NUM_SAMPLES_CLASSIFY=500,NUM_SAMPLES_REGRESS=1200,DENSITY=100;!function(HoverType){HoverType[HoverType.BIAS=0]="BIAS",HoverType[HoverType.WEIGHT=1]="WEIGHT"}(HoverType||(HoverType={}));var INPUTS={x:{f:function(x,y){return x},label:"X_1"},y:{f:function(x,y){return y},label:"X_2"},xSquared:{f:function(x,y){return x*x},label:"X_1^2"},ySquared:{f:function(x,y){return y*y},label:"X_2^2"},xTimesY:{f:function(x,y){return x*y},label:"X_1X_2"},sinX:{f:function(x,y){return Math.sin(x)},label:"sin(X_1)"},sinY:{f:function(x,y){return Math.sin(y)},label:"sin(X_2)"}},HIDABLE_CONTROLS=[["Show test data","showTestData"],["Discretize output","discretize"],["Play button","playButton"],["Step button","stepButton"],["Reset button","resetButton"],["Learning rate","learningRate"],["Activation","activation"],["Regularization","regularization"],["Regularization rate","regularizationRate"],["Problem type","problem"],["Which dataset","dataset"],["Ratio train data","percTrainData"],["Noise level","noise"],["Batch size","batchSize"],["# of hidden layers","numHiddenLayers"]],Player=function(){function Player(){this.timerIndex=0,this.isPlaying=!1,this.callback=null}return Player.prototype.playOrPause=function(){this.isPlaying?(this.isPlaying=!1,this.pause()):(this.isPlaying=!0,this.play())},Player.prototype.onPlayPause=function(callback){this.callback=callback},Player.prototype.play=function(){this.pause(),this.isPlaying=!0,this.callback&&this.callback(this.isPlaying),this.start(this.timerIndex)},Player.prototype.pause=function(){this.timerIndex++,this.isPlaying=!1,this.callback&&this.callback(this.isPlaying)},Player.prototype.start=function(localTimerIndex){var _this=this;d3.timer(function(){return localTimerIndex<_this.timerIndex?!0:(oneStep(),!1)},0)},Player}(),state=state_1.State.deserializeState();state.getHiddenProps().forEach(function(prop){prop in INPUTS&&delete INPUTS[prop]});var boundary={},selectedNodeId=null,xDomain=[-6,6],heatMap=new heatmap_1.HeatMap(300,DENSITY,xDomain,xDomain,d3.select("#heatmap"),{showAxes:!0}),linkWidthScale=d3.scale.linear().domain([0,5]).range([1,10]).clamp(!0),colorScale=d3.scale.linear().domain([-1,0,1]).range(["#f59322","#e8eaeb","#0877bd"]).clamp(!0),iter=0,trainData=[],testData=[],network=null,lossTrain=0,lossTest=0,player=new Player,lineChart=new linechart_1.AppendingLineChart(d3.select("#linechart"),["#777","black"]);exports.getOutputWeights=getOutputWeights,drawDatasetThumbnails(),initTutorial(),makeGUI(),generateData(!0),reset(),hideControls()},{"./dataset":1,"./heatmap":2,"./linechart":3,"./nn":4,"./state":6}],6:[function(require,module,exports){"use strict";function getKeyFromValue(obj,value){for(var key in obj)if(obj[key]===value)return key}function endsWith(s,suffix){return s.substr(-suffix.length)===suffix}function getHideProps(obj){var result=[];for(var prop in obj)endsWith(prop,HIDE_STATE_SUFFIX)&&result.push(prop);return result}var nn=require("./nn"),dataset=require("./dataset"),HIDE_STATE_SUFFIX="_hide";exports.activations={relu:nn.Activations.RELU,tanh:nn.Activations.TANH,sigmoid:nn.Activations.SIGMOID,linear:nn.Activations.LINEAR},exports.regularizations={none:null,L1:nn.RegularizationFunction.L1,L2:nn.RegularizationFunction.L2},exports.datasets={circle:dataset.classifyCircleData,xor:dataset.classifyXORData,gauss:dataset.classifyTwoGaussData,spiral:dataset.classifySpiralData},exports.regDatasets={"reg-plane":dataset.regressPlane,"reg-gauss":dataset.regressGaussian},exports.getKeyFromValue=getKeyFromValue,function(Type){Type[Type.STRING=0]="STRING",Type[Type.NUMBER=1]="NUMBER",Type[Type.ARRAY_NUMBER=2]="ARRAY_NUMBER",Type[Type.ARRAY_STRING=3]="ARRAY_STRING",Type[Type.BOOLEAN=4]="BOOLEAN",Type[Type.OBJECT=5]="OBJECT"}(exports.Type||(exports.Type={}));var Type=exports.Type;!function(Problem){Problem[Problem.CLASSIFICATION=0]="CLASSIFICATION",Problem[Problem.REGRESSION=1]="REGRESSION"}(exports.Problem||(exports.Problem={}));var Problem=exports.Problem;exports.problems={classification:Problem.CLASSIFICATION,regression:Problem.REGRESSION};var State=function(){function State(){this.learningRate=.03,this.regularizationRate=0,this.showTestData=!1,this.noise=0,this.batchSize=10,this.discretize=!1,this.tutorial=null,this.percTrainData=50,this.activation=nn.Activations.TANH,this.regularization=null,this.problem=Problem.CLASSIFICATION,this.collectStats=!1,this.numHiddenLayers=1,this.hiddenLayerControls=[],this.networkShape=[4,2],this.x=!0,this.y=!0,this.xTimesY=!1,this.xSquared=!1,this.ySquared=!1,this.cosX=!1,this.sinX=!1,this.cosY=!1,this.sinY=!1,this.dataset=dataset.classifyCircleData,this.regDataset=dataset.regressPlane}return State.deserializeState=function(){function hasKey(name){return name in map&&null!=map[name]&&""!==map[name].trim()}function parseArray(value){return""===value.trim()?[]:value.split(",")}for(var map={},_i=0,_a=window.location.hash.slice(1).split("&");_i<_a.length;_i++){var keyvalue=_a[_i],_b=keyvalue.split("="),name_1=_b[0],value=_b[1];map[name_1]=value}var state=new State;return State.PROPS.forEach(function(_a){var name=_a.name,type=_a.type,keyMap=_a.keyMap;switch(type){case Type.OBJECT:if(null==keyMap)throw Error("A key-value map must be provided for state variables of type Object");hasKey(name)&&map[name]in keyMap&&(state[name]=keyMap[map[name]]);break;case Type.NUMBER:hasKey(name)&&(state[name]=+map[name]);break;case Type.STRING:hasKey(name)&&(state[name]=map[name]);break;case Type.BOOLEAN:hasKey(name)&&(state[name]="false"!==map[name]);break;case Type.ARRAY_NUMBER:name in map&&(state[name]=parseArray(map[name]).map(Number));break;case Type.ARRAY_STRING:name in map&&(state[name]=parseArray(map[name]));break;default:throw Error("Encountered an unknown type for a state variable")}}),getHideProps(map).forEach(function(prop){state[prop]="true"===map[prop]}),state.numHiddenLayers=state.networkShape.length,null==state.seed&&(state.seed=Math.random().toFixed(5)),Math.seedrandom(state.seed),state},State.prototype.serialize=function(){var _this=this,props=[];State.PROPS.forEach(function(_a){var name=_a.name,type=_a.type,keyMap=_a.keyMap,value=_this[name];null!=value&&(type===Type.OBJECT?value=getKeyFromValue(keyMap,value):type!==Type.ARRAY_NUMBER&&type!==Type.ARRAY_STRING||(value=value.join(",")),props.push(name+"="+value))}),getHideProps(this).forEach(function(prop){props.push(prop+"="+_this[prop])}),window.location.hash=props.join("&")},State.prototype.getHiddenProps=function(){var result=[];for(var prop in this)endsWith(prop,HIDE_STATE_SUFFIX)&&this[prop]===!0&&result.push(prop.replace(HIDE_STATE_SUFFIX,""));return result},State.prototype.setHideProperty=function(name,hidden){this[name+HIDE_STATE_SUFFIX]=hidden},State.PROPS=[{name:"activation",type:Type.OBJECT,keyMap:exports.activations},{name:"regularization",type:Type.OBJECT,keyMap:exports.regularizations},{name:"batchSize",type:Type.NUMBER},{name:"dataset",type:Type.OBJECT,keyMap:exports.datasets},{name:"regDataset",type:Type.OBJECT,keyMap:exports.regDatasets},{name:"learningRate",type:Type.NUMBER},{name:"regularizationRate",type:Type.NUMBER},{name:"noise",type:Type.NUMBER},{name:"networkShape",type:Type.ARRAY_NUMBER},{name:"seed",type:Type.STRING},{name:"showTestData",type:Type.BOOLEAN},{name:"discretize",type:Type.BOOLEAN},{name:"percTrainData",type:Type.NUMBER},{name:"x",type:Type.BOOLEAN},{name:"y",type:Type.BOOLEAN},{name:"xTimesY",type:Type.BOOLEAN},{name:"xSquared",type:Type.BOOLEAN},{name:"ySquared",type:Type.BOOLEAN},{name:"cosX",type:Type.BOOLEAN},{name:"sinX",type:Type.BOOLEAN},{name:"cosY",type:Type.BOOLEAN},{name:"sinY",type:Type.BOOLEAN},{name:"collectStats",type:Type.BOOLEAN},{name:"tutorial",type:Type.STRING},{name:"problem",type:Type.OBJECT,keyMap:exports.problems}],State}();exports.State=State},{"./dataset":1,"./nn":4}]},{},[5]);
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+function shuffle(array) {
+    var counter = array.length;
+    var temp = 0;
+    var index = 0;
+    while (counter > 0) {
+        index = Math.floor(Math.random() * counter);
+        counter--;
+        temp = array[counter];
+        array[counter] = array[index];
+        array[index] = temp;
+    }
+}
+exports.shuffle = shuffle;
+function classifyTwoGaussData(numSamples, noise) {
+    var points = [];
+    var varianceScale = d3.scale.linear().domain([0, .5]).range([0.5, 4]);
+    var variance = varianceScale(noise);
+    function genGauss(cx, cy, label) {
+        for (var i = 0; i < numSamples / 2; i++) {
+            var x = normalRandom(cx, variance);
+            var y = normalRandom(cy, variance);
+            points.push({ x: x, y: y, label: label });
+        }
+    }
+    genGauss(2, 2, 1);
+    genGauss(-2, -2, -1);
+    return points;
+}
+exports.classifyTwoGaussData = classifyTwoGaussData;
+function regressPlane(numSamples, noise) {
+    var radius = 6;
+    var labelScale = d3.scale.linear()
+        .domain([-10, 10])
+        .range([-1, 1]);
+    var getLabel = function (x, y) { return labelScale(x + y); };
+    var points = [];
+    for (var i = 0; i < numSamples; i++) {
+        var x = randUniform(-radius, radius);
+        var y = randUniform(-radius, radius);
+        var noiseX = randUniform(-radius, radius) * noise;
+        var noiseY = randUniform(-radius, radius) * noise;
+        var label = getLabel(x + noiseX, y + noiseY);
+        points.push({ x: x, y: y, label: label });
+    }
+    return points;
+}
+exports.regressPlane = regressPlane;
+function regressGaussian(numSamples, noise) {
+    var points = [];
+    var labelScale = d3.scale.linear()
+        .domain([0, 2])
+        .range([1, 0])
+        .clamp(true);
+    var gaussians = [
+        [-4, 2.5, 1],
+        [0, 2.5, -1],
+        [4, 2.5, 1],
+        [-4, -2.5, -1],
+        [0, -2.5, 1],
+        [4, -2.5, -1]
+    ];
+    function getLabel(x, y) {
+        var label = 0;
+        gaussians.forEach(function (_a) {
+            var cx = _a[0], cy = _a[1], sign = _a[2];
+            var newLabel = sign * labelScale(dist({ x: x, y: y }, { x: cx, y: cy }));
+            if (Math.abs(newLabel) > Math.abs(label)) {
+                label = newLabel;
+            }
+        });
+        return label;
+    }
+    var radius = 6;
+    for (var i = 0; i < numSamples; i++) {
+        var x = randUniform(-radius, radius);
+        var y = randUniform(-radius, radius);
+        var noiseX = randUniform(-radius, radius) * noise;
+        var noiseY = randUniform(-radius, radius) * noise;
+        var label = getLabel(x + noiseX, y + noiseY);
+        points.push({ x: x, y: y, label: label });
+    }
+    ;
+    return points;
+}
+exports.regressGaussian = regressGaussian;
+function classifySpiralData(numSamples, noise) {
+    var points = [];
+    var n = numSamples / 2;
+    function genSpiral(deltaT, label) {
+        for (var i = 0; i < n; i++) {
+            var r = i / n * 5;
+            var t = 1.75 * i / n * 2 * Math.PI + deltaT;
+            var x = r * Math.sin(t) + randUniform(-1, 1) * noise;
+            var y = r * Math.cos(t) + randUniform(-1, 1) * noise;
+            points.push({ x: x, y: y, label: label });
+        }
+    }
+    genSpiral(0, 1);
+    genSpiral(Math.PI, -1);
+    return points;
+}
+exports.classifySpiralData = classifySpiralData;
+function classifyCircleData(numSamples, noise) {
+    var points = [];
+    var radius = 5;
+    function getCircleLabel(p, center) {
+        return (dist(p, center) < (radius * 0.5)) ? 1 : -1;
+    }
+    for (var i = 0; i < numSamples / 2; i++) {
+        var r = randUniform(0, radius * 0.5);
+        var angle = randUniform(0, 2 * Math.PI);
+        var x = r * Math.sin(angle);
+        var y = r * Math.cos(angle);
+        var noiseX = randUniform(-radius, radius) * noise;
+        var noiseY = randUniform(-radius, radius) * noise;
+        var label = getCircleLabel({ x: x + noiseX, y: y + noiseY }, { x: 0, y: 0 });
+        points.push({ x: x, y: y, label: label });
+    }
+    for (var i = 0; i < numSamples / 2; i++) {
+        var r = randUniform(radius * 0.7, radius);
+        var angle = randUniform(0, 2 * Math.PI);
+        var x = r * Math.sin(angle);
+        var y = r * Math.cos(angle);
+        var noiseX = randUniform(-radius, radius) * noise;
+        var noiseY = randUniform(-radius, radius) * noise;
+        var label = getCircleLabel({ x: x + noiseX, y: y + noiseY }, { x: 0, y: 0 });
+        points.push({ x: x, y: y, label: label });
+    }
+    return points;
+}
+exports.classifyCircleData = classifyCircleData;
+function classifyXORData(numSamples, noise) {
+    function getXORLabel(p) { return p.x * p.y >= 0 ? 1 : -1; }
+    var points = [];
+    for (var i = 0; i < numSamples; i++) {
+        var x = randUniform(-5, 5);
+        var padding = 0.3;
+        x += x > 0 ? padding : -padding;
+        var y = randUniform(-5, 5);
+        y += y > 0 ? padding : -padding;
+        var noiseX = randUniform(-5, 5) * noise;
+        var noiseY = randUniform(-5, 5) * noise;
+        var label = getXORLabel({ x: x + noiseX, y: y + noiseY });
+        points.push({ x: x, y: y, label: label });
+    }
+    return points;
+}
+exports.classifyXORData = classifyXORData;
+function randUniform(a, b) {
+    return Math.random() * (b - a) + a;
+}
+function normalRandom(mean, variance) {
+    if (mean === void 0) { mean = 0; }
+    if (variance === void 0) { variance = 1; }
+    var v1, v2, s;
+    do {
+        v1 = 2 * Math.random() - 1;
+        v2 = 2 * Math.random() - 1;
+        s = v1 * v1 + v2 * v2;
+    } while (s > 1);
+    var result = Math.sqrt(-2 * Math.log(s) / s) * v1;
+    return mean + Math.sqrt(variance) * result;
+}
+function dist(a, b) {
+    var dx = a.x - b.x;
+    var dy = a.y - b.y;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+},{}],2:[function(require,module,exports){
+"use strict";
+var NUM_SHADES = 30;
+var HeatMap = (function () {
+    function HeatMap(width, numSamples, xDomain, yDomain, container, userSettings) {
+        this.settings = {
+            showAxes: false,
+            noSvg: false
+        };
+        this.numSamples = numSamples;
+        var height = width;
+        var padding = userSettings.showAxes ? 20 : 0;
+        if (userSettings != null) {
+            for (var prop in userSettings) {
+                this.settings[prop] = userSettings[prop];
+            }
+        }
+        this.xScale = d3.scale.linear()
+            .domain(xDomain)
+            .range([0, width - 2 * padding]);
+        this.yScale = d3.scale.linear()
+            .domain(yDomain)
+            .range([height - 2 * padding, 0]);
+        var tmpScale = d3.scale.linear()
+            .domain([0, .5, 1])
+            .range(["#f59322", "#e8eaeb", "#0877bd"])
+            .clamp(true);
+        var colors = d3.range(0, 1 + 1E-9, 1 / NUM_SHADES).map(function (a) {
+            return tmpScale(a);
+        });
+        this.color = d3.scale.quantize()
+            .domain([-1, 1])
+            .range(colors);
+        container = container.append("div")
+            .style({
+            width: width + "px",
+            height: height + "px",
+            position: "relative",
+            top: "-" + padding + "px",
+            left: "-" + padding + "px"
+        });
+        this.canvas = container.append("canvas")
+            .attr("width", numSamples)
+            .attr("height", numSamples)
+            .style("width", (width - 2 * padding) + "px")
+            .style("height", (height - 2 * padding) + "px")
+            .style("position", "absolute")
+            .style("top", padding + "px")
+            .style("left", padding + "px");
+        if (!this.settings.noSvg) {
+            this.svg = container.append("svg").attr({
+                "width": width,
+                "height": height
+            }).style({
+                "position": "absolute",
+                "left": "0",
+                "top": "0"
+            }).append("g")
+                .attr("transform", "translate(" + padding + "," + padding + ")");
+            this.svg.append("g").attr("class", "train");
+            this.svg.append("g").attr("class", "test");
+        }
+        if (this.settings.showAxes) {
+            var xAxis = d3.svg.axis()
+                .scale(this.xScale)
+                .orient("bottom");
+            var yAxis = d3.svg.axis()
+                .scale(this.yScale)
+                .orient("right");
+            this.svg.append("g")
+                .attr("class", "x axis")
+                .attr("transform", "translate(0," + (height - 2 * padding) + ")")
+                .call(xAxis);
+            this.svg.append("g")
+                .attr("class", "y axis")
+                .attr("transform", "translate(" + (width - 2 * padding) + ",0)")
+                .call(yAxis);
+        }
+    }
+    HeatMap.prototype.updateTestPoints = function (points) {
+        if (this.settings.noSvg) {
+            throw Error("Can't add points since noSvg=true");
+        }
+        this.updateCircles(this.svg.select("g.test"), points);
+    };
+    HeatMap.prototype.updatePoints = function (points) {
+        if (this.settings.noSvg) {
+            throw Error("Can't add points since noSvg=true");
+        }
+        this.updateCircles(this.svg.select("g.train"), points);
+    };
+    HeatMap.prototype.updateBackground = function (data, discretize) {
+        var dx = data[0].length;
+        var dy = data.length;
+        if (dx !== this.numSamples || dy !== this.numSamples) {
+            throw new Error("The provided data matrix must be of size " +
+                "numSamples X numSamples");
+        }
+        var context = this.canvas.node().getContext("2d");
+        var image = context.createImageData(dx, dy);
+        for (var y = 0, p = -1; y < dy; ++y) {
+            for (var x = 0; x < dx; ++x) {
+                var value = data[x][y];
+                if (discretize) {
+                    value = (value >= 0 ? 1 : -1);
+                }
+                var c = d3.rgb(this.color(value));
+                image.data[++p] = c.r;
+                image.data[++p] = c.g;
+                image.data[++p] = c.b;
+                image.data[++p] = 160;
+            }
+        }
+        context.putImageData(image, 0, 0);
+    };
+    HeatMap.prototype.updateCircles = function (container, points) {
+        var _this = this;
+        var xDomain = this.xScale.domain();
+        var yDomain = this.yScale.domain();
+        points = points.filter(function (p) {
+            return p.x >= xDomain[0] && p.x <= xDomain[1]
+                && p.y >= yDomain[0] && p.y <= yDomain[1];
+        });
+        var selection = container.selectAll("circle").data(points);
+        selection.enter().append("circle").attr("r", 3);
+        selection
+            .attr({
+            cx: function (d) { return _this.xScale(d.x); },
+            cy: function (d) { return _this.yScale(d.y); }
+        })
+            .style("fill", function (d) { return _this.color(d.label); });
+        selection.exit().remove();
+    };
+    return HeatMap;
+}());
+exports.HeatMap = HeatMap;
+function reduceMatrix(matrix, factor) {
+    if (matrix.length !== matrix[0].length) {
+        throw new Error("The provided matrix must be a square matrix");
+    }
+    if (matrix.length % factor !== 0) {
+        throw new Error("The width/height of the matrix must be divisible by " +
+            "the reduction factor");
+    }
+    var result = new Array(matrix.length / factor);
+    for (var i = 0; i < matrix.length; i += factor) {
+        result[i / factor] = new Array(matrix.length / factor);
+        for (var j = 0; j < matrix.length; j += factor) {
+            var avg = 0;
+            for (var k = 0; k < factor; k++) {
+                for (var l = 0; l < factor; l++) {
+                    avg += matrix[i + k][j + l];
+                }
+            }
+            avg /= (factor * factor);
+            result[i / factor][j / factor] = avg;
+        }
+    }
+    return result;
+}
+exports.reduceMatrix = reduceMatrix;
+
+},{}],3:[function(require,module,exports){
+"use strict";
+var AppendingLineChart = (function () {
+    function AppendingLineChart(container, lineColors) {
+        this.data = [];
+        this.minY = Number.MAX_VALUE;
+        this.maxY = Number.MIN_VALUE;
+        this.lineColors = lineColors;
+        this.numLines = lineColors.length;
+        var node = container.node();
+        var totalWidth = node.offsetWidth;
+        var totalHeight = node.offsetHeight;
+        var margin = { top: 2, right: 0, bottom: 2, left: 2 };
+        var width = totalWidth - margin.left - margin.right;
+        var height = totalHeight - margin.top - margin.bottom;
+        this.xScale = d3.scale.linear()
+            .domain([0, 0])
+            .range([0, width]);
+        this.yScale = d3.scale.linear()
+            .domain([0, 0])
+            .range([height, 0]);
+        this.svg = container.append("svg")
+            .attr("width", width + margin.left + margin.right)
+            .attr("height", height + margin.top + margin.bottom)
+            .append("g")
+            .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+        this.paths = new Array(this.numLines);
+        for (var i = 0; i < this.numLines; i++) {
+            this.paths[i] = this.svg.append("path")
+                .attr("class", "line")
+                .style({
+                "fill": "none",
+                "stroke": lineColors[i],
+                "stroke-width": "1.5px"
+            });
+        }
+    }
+    AppendingLineChart.prototype.reset = function () {
+        this.data = [];
+        this.redraw();
+        this.minY = Number.MAX_VALUE;
+        this.maxY = Number.MIN_VALUE;
+    };
+    AppendingLineChart.prototype.addDataPoint = function (dataPoint) {
+        var _this = this;
+        if (dataPoint.length !== this.numLines) {
+            throw Error("Length of dataPoint must equal number of lines");
+        }
+        dataPoint.forEach(function (y) {
+            _this.minY = Math.min(_this.minY, y);
+            _this.maxY = Math.max(_this.maxY, y);
+        });
+        this.data.push({ x: this.data.length + 1, y: dataPoint });
+        this.redraw();
+    };
+    AppendingLineChart.prototype.redraw = function () {
+        var _this = this;
+        this.xScale.domain([1, this.data.length]);
+        this.yScale.domain([this.minY, this.maxY]);
+        var getPathMap = function (lineIndex) {
+            return d3.svg.line()
+                .x(function (d) { return _this.xScale(d.x); })
+                .y(function (d) { return _this.yScale(d.y[lineIndex]); });
+        };
+        for (var i = 0; i < this.numLines; i++) {
+            this.paths[i].datum(this.data).attr("d", getPathMap(i));
+        }
+    };
+    return AppendingLineChart;
+}());
+exports.AppendingLineChart = AppendingLineChart;
+
+},{}],4:[function(require,module,exports){
+"use strict";
+var Node = (function () {
+    function Node(id, activation) {
+        this.inputLinks = [];
+        this.bias = 0.1;
+        this.outputs = [];
+        this.outputDer = 0;
+        this.inputDer = 0;
+        this.accInputDer = 0;
+        this.numAccumulatedDers = 0;
+        this.id = id;
+        this.activation = activation;
+    }
+    Node.prototype.updateOutput = function () {
+        this.totalInput = this.bias;
+        for (var j = 0; j < this.inputLinks.length; j++) {
+            var link = this.inputLinks[j];
+            this.totalInput += link.weight * link.source.output;
+        }
+        this.output = this.activation.output(this.totalInput);
+        return this.output;
+    };
+    return Node;
+}());
+exports.Node = Node;
+var Errors = (function () {
+    function Errors() {
+    }
+    Errors.SQUARE = {
+        error: function (output, target) {
+            return 0.5 * Math.pow(output - target, 2);
+        },
+        der: function (output, target) { return output - target; }
+    };
+    return Errors;
+}());
+exports.Errors = Errors;
+Math.tanh = Math.tanh || function (x) {
+    if (x === Infinity) {
+        return 1;
+    }
+    else if (x === -Infinity) {
+        return -1;
+    }
+    else {
+        var e2x = Math.exp(2 * x);
+        return (e2x - 1) / (e2x + 1);
+    }
+};
+var Activations = (function () {
+    function Activations() {
+    }
+    Activations.ARCTAN = {
+        output: function (x) { return Math.atan(x); },
+        der: function (x) { return 1 / (x * x + 1); }
+    };
+    Activations.BENT = {
+        output: function (x) { return (Math.sqrt(x * x + 1) - 1) / 2 + x; },
+        der: function (x) { return x / (2 * Math.sqrt(x * x + 1)) + 1; }
+    };
+    Activations.ELU = {
+        output: function (x) { return x < 0 ? Math.exp(x) - 1 : x; },
+        der: function (x) {
+            var output = Activations.ELU.output(x);
+            return x < 0 ? output + 1 : 1;
+        }
+    };
+    Activations.GAUSSIAN = {
+        output: function (x) { return Math.exp(-x * x); },
+        der: function (x) {
+            var output = Activations.GAUSSIAN.output(x);
+            return -2 * x * output;
+        }
+    };
+    Activations.LINEAR = {
+        output: function (x) { return x; },
+        der: function (x) { return 1; }
+    };
+    Activations.RELU = {
+        output: function (x) { return Math.max(0, x); },
+        der: function (x) { return x <= 0 ? 0 : 1; }
+    };
+    Activations.SIGMOID = {
+        output: function (x) { return 1 / (1 + Math.exp(-x)); },
+        der: function (x) {
+            var output = Activations.SIGMOID.output(x);
+            return output * (1 - output);
+        }
+    };
+    Activations.SINUSOID = {
+        output: function (x) { return Math.sin(x); },
+        der: function (x) { return Math.cos(x); }
+    };
+    Activations.SOFTPLUS = {
+        output: function (x) { return Math.log(1 + Math.exp(x)); },
+        der: function (x) { return Activations.SIGMOID.output(x); }
+    };
+    Activations.SOFTSIGN = {
+        output: function (x) { return x / (1 + Math.abs(x)); },
+        der: function (x) {
+            var root = 1 / (1 + Math.abs(x));
+            return root * root;
+        }
+    };
+    Activations.TANH = {
+        output: function (x) { return Math.tanh(x); },
+        der: function (x) {
+            var output = Activations.TANH.output(x);
+            return 1 - output * output;
+        }
+    };
+    return Activations;
+}());
+exports.Activations = Activations;
+var RegularizationFunction = (function () {
+    function RegularizationFunction() {
+    }
+    RegularizationFunction.L1 = {
+        output: function (w) { return Math.abs(w); },
+        der: function (w) { return w < 0 ? -1 : 1; }
+    };
+    RegularizationFunction.L2 = {
+        output: function (w) { return 0.5 * w * w; },
+        der: function (w) { return w; }
+    };
+    return RegularizationFunction;
+}());
+exports.RegularizationFunction = RegularizationFunction;
+var Link = (function () {
+    function Link(source, dest, regularization) {
+        this.weight = Math.random() - 0.5;
+        this.errorDer = 0;
+        this.accErrorDer = 0;
+        this.numAccumulatedDers = 0;
+        this.id = source.id + "-" + dest.id;
+        this.source = source;
+        this.dest = dest;
+        this.regularization = regularization;
+    }
+    return Link;
+}());
+exports.Link = Link;
+function buildNetwork(networkShape, activation, outputActivation, regularization, inputIds) {
+    var numLayers = networkShape.length;
+    var id = 1;
+    var network = [];
+    for (var layerIdx = 0; layerIdx < numLayers; layerIdx++) {
+        var isOutputLayer = layerIdx === numLayers - 1;
+        var isInputLayer = layerIdx === 0;
+        var currentLayer = [];
+        network.push(currentLayer);
+        var numNodes = networkShape[layerIdx];
+        for (var i = 0; i < numNodes; i++) {
+            var nodeId = id.toString();
+            if (isInputLayer) {
+                nodeId = inputIds[i];
+            }
+            else {
+                id++;
+            }
+            var node = new Node(nodeId, isOutputLayer ? outputActivation : activation);
+            currentLayer.push(node);
+            if (layerIdx >= 1) {
+                for (var j = 0; j < network[layerIdx - 1].length; j++) {
+                    var prevNode = network[layerIdx - 1][j];
+                    var link = new Link(prevNode, node, regularization);
+                    prevNode.outputs.push(link);
+                    node.inputLinks.push(link);
+                }
+            }
+        }
+    }
+    return network;
+}
+exports.buildNetwork = buildNetwork;
+function forwardProp(network, inputs) {
+    var inputLayer = network[0];
+    if (inputs.length !== inputLayer.length) {
+        throw new Error("The number of inputs must match the number of nodes in" +
+            " the input layer");
+    }
+    for (var i = 0; i < inputLayer.length; i++) {
+        var node = inputLayer[i];
+        node.output = inputs[i];
+    }
+    for (var layerIdx = 1; layerIdx < network.length; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            node.updateOutput();
+        }
+    }
+    return network[network.length - 1][0].output;
+}
+exports.forwardProp = forwardProp;
+function backProp(network, target, errorFunc) {
+    var outputNode = network[network.length - 1][0];
+    outputNode.outputDer = errorFunc.der(outputNode.output, target);
+    for (var layerIdx = network.length - 1; layerIdx >= 1; layerIdx--) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            node.inputDer = node.outputDer * node.activation.der(node.totalInput);
+            node.accInputDer += node.inputDer;
+            node.numAccumulatedDers++;
+        }
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            for (var j = 0; j < node.inputLinks.length; j++) {
+                var link = node.inputLinks[j];
+                link.errorDer = node.inputDer * link.source.output;
+                link.accErrorDer += link.errorDer;
+                link.numAccumulatedDers++;
+            }
+        }
+        if (layerIdx === 1) {
+            continue;
+        }
+        var prevLayer = network[layerIdx - 1];
+        for (var i = 0; i < prevLayer.length; i++) {
+            var node = prevLayer[i];
+            node.outputDer = 0;
+            for (var j = 0; j < node.outputs.length; j++) {
+                var output = node.outputs[j];
+                node.outputDer += output.weight * output.dest.inputDer;
+            }
+        }
+    }
+}
+exports.backProp = backProp;
+function updateWeights(network, learningRate, regularizationRate) {
+    for (var layerIdx = 1; layerIdx < network.length; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            if (node.numAccumulatedDers > 0) {
+                node.bias -= learningRate * node.accInputDer / node.numAccumulatedDers;
+                node.accInputDer = 0;
+                node.numAccumulatedDers = 0;
+            }
+            for (var j = 0; j < node.inputLinks.length; j++) {
+                var link = node.inputLinks[j];
+                var regulDer = link.regularization ?
+                    link.regularization.der(link.weight) : 0;
+                if (link.numAccumulatedDers > 0) {
+                    link.weight -= (learningRate / link.numAccumulatedDers) *
+                        (link.accErrorDer + regularizationRate * regulDer);
+                    link.accErrorDer = 0;
+                    link.numAccumulatedDers = 0;
+                }
+            }
+        }
+    }
+}
+exports.updateWeights = updateWeights;
+function forEachNode(network, ignoreInputs, accessor) {
+    for (var layerIdx = ignoreInputs ? 1 : 0; layerIdx < network.length; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            accessor(node);
+        }
+    }
+}
+exports.forEachNode = forEachNode;
+function getOutputNode(network) {
+    return network[network.length - 1][0];
+}
+exports.getOutputNode = getOutputNode;
+
+},{}],5:[function(require,module,exports){
+"use strict";
+var nn = require("./nn");
+var heatmap_1 = require("./heatmap");
+var state_1 = require("./state");
+var dataset_1 = require("./dataset");
+var linechart_1 = require("./linechart");
+var mainWidth;
+d3.select(".more button").on("click", function () {
+    var position = 800;
+    d3.transition()
+        .duration(1000)
+        .tween("scroll", scrollTween(position));
+});
+function scrollTween(offset) {
+    return function () {
+        var i = d3.interpolateNumber(window.pageYOffset ||
+            document.documentElement.scrollTop, offset);
+        return function (t) { scrollTo(0, i(t)); };
+    };
+}
+var RECT_SIZE = 30;
+var BIAS_SIZE = 5;
+var NUM_SAMPLES_CLASSIFY = 500;
+var NUM_SAMPLES_REGRESS = 1200;
+var DENSITY = 100;
+var HoverType;
+(function (HoverType) {
+    HoverType[HoverType["BIAS"] = 0] = "BIAS";
+    HoverType[HoverType["WEIGHT"] = 1] = "WEIGHT";
+})(HoverType || (HoverType = {}));
+var INPUTS = {
+    "x": { f: function (x, y) { return x; }, label: "X_1" },
+    "y": { f: function (x, y) { return y; }, label: "X_2" },
+    "xSquared": { f: function (x, y) { return x * x; }, label: "X_1^2" },
+    "ySquared": { f: function (x, y) { return y * y; }, label: "X_2^2" },
+    "xTimesY": { f: function (x, y) { return x * y; }, label: "X_1X_2" },
+    "sinX": { f: function (x, y) { return Math.sin(x); }, label: "sin(X_1)" },
+    "sinY": { f: function (x, y) { return Math.sin(y); }, label: "sin(X_2)" }
+};
+var HIDABLE_CONTROLS = [
+    ["Show test data", "showTestData"],
+    ["Discretize output", "discretize"],
+    ["Play button", "playButton"],
+    ["Step button", "stepButton"],
+    ["Reset button", "resetButton"],
+    ["Learning rate", "learningRate"],
+    ["Activation", "activation"],
+    ["Regularization", "regularization"],
+    ["Regularization rate", "regularizationRate"],
+    ["Problem type", "problem"],
+    ["Which dataset", "dataset"],
+    ["Ratio train data", "percTrainData"],
+    ["Noise level", "noise"],
+    ["Batch size", "batchSize"],
+    ["# of hidden layers", "numHiddenLayers"],
+];
+var Player = (function () {
+    function Player() {
+        this.timerIndex = 0;
+        this.isPlaying = false;
+        this.callback = null;
+    }
+    Player.prototype.playOrPause = function () {
+        if (this.isPlaying) {
+            this.isPlaying = false;
+            this.pause();
+        }
+        else {
+            this.isPlaying = true;
+            this.play();
+        }
+    };
+    Player.prototype.onPlayPause = function (callback) {
+        this.callback = callback;
+    };
+    Player.prototype.play = function () {
+        this.pause();
+        this.isPlaying = true;
+        if (this.callback) {
+            this.callback(this.isPlaying);
+        }
+        this.start(this.timerIndex);
+    };
+    Player.prototype.pause = function () {
+        this.timerIndex++;
+        this.isPlaying = false;
+        if (this.callback) {
+            this.callback(this.isPlaying);
+        }
+    };
+    Player.prototype.start = function (localTimerIndex) {
+        var _this = this;
+        d3.timer(function () {
+            if (localTimerIndex < _this.timerIndex) {
+                return true;
+            }
+            oneStep();
+            return false;
+        }, 0);
+    };
+    return Player;
+}());
+var state = state_1.State.deserializeState();
+state.getHiddenProps().forEach(function (prop) {
+    if (prop in INPUTS) {
+        delete INPUTS[prop];
+    }
+});
+var boundary = {};
+var selectedNodeId = null;
+var xDomain = [-6, 6];
+var heatMap = new heatmap_1.HeatMap(300, DENSITY, xDomain, xDomain, d3.select("#heatmap"), { showAxes: true });
+var linkWidthScale = d3.scale.linear()
+    .domain([0, 5])
+    .range([1, 10])
+    .clamp(true);
+var colorScale = d3.scale.linear()
+    .domain([-1, 0, 1])
+    .range(["#f59322", "#e8eaeb", "#0877bd"])
+    .clamp(true);
+var iter = 0;
+var trainData = [];
+var testData = [];
+var network = null;
+var lossTrain = 0;
+var lossTest = 0;
+var player = new Player();
+var lineChart = new linechart_1.AppendingLineChart(d3.select("#linechart"), ["#777", "black"]);
+function makeGUI() {
+    d3.select("#reset-button").on("click", function () {
+        reset();
+        d3.select("#play-pause-button");
+    });
+    d3.select("#play-pause-button").on("click", function () {
+        player.playOrPause();
+    });
+    player.onPlayPause(function (isPlaying) {
+        d3.select("#play-pause-button").classed("playing", isPlaying);
+    });
+    d3.select("#next-step-button").on("click", function () {
+        player.pause();
+        oneStep();
+    });
+    d3.select("#data-regen-button").on("click", function () {
+        generateData();
+    });
+    var dataThumbnails = d3.selectAll("canvas[data-dataset]");
+    dataThumbnails.on("click", function () {
+        var newDataset = state_1.datasets[this.dataset.dataset];
+        if (newDataset === state.dataset) {
+            return;
+        }
+        state.dataset = newDataset;
+        dataThumbnails.classed("selected", false);
+        d3.select(this).classed("selected", true);
+        generateData();
+        reset();
+    });
+    var datasetKey = state_1.getKeyFromValue(state_1.datasets, state.dataset);
+    d3.select("canvas[data-dataset=" + datasetKey + "]")
+        .classed("selected", true);
+    var regDataThumbnails = d3.selectAll("canvas[data-regDataset]");
+    regDataThumbnails.on("click", function () {
+        var newDataset = state_1.regDatasets[this.dataset.regdataset];
+        if (newDataset === state.regDataset) {
+            return;
+        }
+        state.regDataset = newDataset;
+        regDataThumbnails.classed("selected", false);
+        d3.select(this).classed("selected", true);
+        generateData();
+        reset();
+    });
+    var regDatasetKey = state_1.getKeyFromValue(state_1.regDatasets, state.regDataset);
+    d3.select("canvas[data-regDataset=" + regDatasetKey + "]")
+        .classed("selected", true);
+    d3.select("#add-layers").on("click", function () {
+        if (state.numHiddenLayers >= 6) {
+            return;
+        }
+        state.networkShape[state.numHiddenLayers] = 2;
+        state.numHiddenLayers++;
+        reset();
+    });
+    d3.select("#remove-layers").on("click", function () {
+        if (state.numHiddenLayers <= 0) {
+            return;
+        }
+        state.numHiddenLayers--;
+        state.networkShape.splice(state.numHiddenLayers);
+        reset();
+    });
+    var showTestData = d3.select("#show-test-data").on("change", function () {
+        state.showTestData = this.checked;
+        state.serialize();
+        heatMap.updateTestPoints(state.showTestData ? testData : []);
+    });
+    showTestData.property("checked", state.showTestData);
+    var discretize = d3.select("#discretize").on("change", function () {
+        state.discretize = this.checked;
+        state.serialize();
+        updateUI();
+    });
+    discretize.property("checked", state.discretize);
+    var percTrain = d3.select("#percTrainData").on("input", function () {
+        state.percTrainData = this.value;
+        d3.select("label[for='percTrainData'] .value").text(this.value);
+        generateData();
+        reset();
+    });
+    percTrain.property("value", state.percTrainData);
+    d3.select("label[for='percTrainData'] .value").text(state.percTrainData);
+    var noise = d3.select("#noise").on("input", function () {
+        state.noise = this.value;
+        d3.select("label[for='noise'] .value").text(this.value);
+        generateData();
+        reset();
+    });
+    noise.property("value", state.noise);
+    d3.select("label[for='noise'] .value").text(state.noise);
+    var batchSize = d3.select("#batchSize").on("input", function () {
+        state.batchSize = this.value;
+        d3.select("label[for='batchSize'] .value").text(this.value);
+        reset();
+    });
+    batchSize.property("value", state.batchSize);
+    d3.select("label[for='batchSize'] .value").text(state.batchSize);
+    var activationDropdown = d3.select("#activations").on("change", function () {
+        state.activation = state_1.activations[this.value];
+        updateActivation();
+    });
+    activationDropdown.property("value", state_1.getKeyFromValue(state_1.activations, state.activation));
+    var learningRate = d3.select("#learningRate").on("change", function () {
+        state.learningRate = +this.value;
+    });
+    learningRate.property("value", state.learningRate);
+    var regularDropdown = d3.select("#regularizations").on("change", function () {
+        state.regularization = state_1.regularizations[this.value];
+        reset();
+    });
+    regularDropdown.property("value", state_1.getKeyFromValue(state_1.regularizations, state.regularization));
+    var regularRate = d3.select("#regularRate").on("change", function () {
+        state.regularizationRate = +this.value;
+        reset();
+    });
+    regularRate.property("value", state.regularizationRate);
+    var problem = d3.select("#problem").on("change", function () {
+        state.problem = state_1.problems[this.value];
+        generateData();
+        drawDatasetThumbnails();
+        reset();
+    });
+    problem.property("value", state_1.getKeyFromValue(state_1.problems, state.problem));
+    var x = d3.scale.linear().domain([-1, 1]).range([0, 144]);
+    var xAxis = d3.svg.axis()
+        .scale(x)
+        .orient("bottom")
+        .tickValues([-1, 0, 1])
+        .tickFormat(d3.format("d"));
+    d3.select("#colormap g.core").append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0,10)")
+        .call(xAxis);
+    window.addEventListener("resize", function () {
+        var newWidth = document.querySelector("#main-part")
+            .getBoundingClientRect().width;
+        if (newWidth !== mainWidth) {
+            mainWidth = newWidth;
+            drawNetwork(network);
+            updateUI(true);
+        }
+    });
+}
+function updateBiasesUI(network) {
+    nn.forEachNode(network, true, function (node) {
+        d3.select("rect#bias-" + node.id).style("fill", colorScale(node.bias));
+    });
+}
+function updateWeightsUI(network, container) {
+    for (var layerIdx = 1; layerIdx < network.length; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            for (var j = 0; j < node.inputLinks.length; j++) {
+                var link = node.inputLinks[j];
+                container.select("#link" + link.source.id + "-" + link.dest.id)
+                    .style({
+                    "stroke-dashoffset": -iter / 3,
+                    "stroke-width": linkWidthScale(Math.abs(link.weight)),
+                    "stroke": colorScale(link.weight)
+                })
+                    .datum(link);
+            }
+        }
+    }
+}
+function drawNode(cx, cy, nodeId, isInput, container, node) {
+    var x = cx - RECT_SIZE / 2;
+    var y = cy - RECT_SIZE / 2;
+    var nodeGroup = container.append("g")
+        .attr({
+        "class": "node",
+        "id": "node" + nodeId,
+        "transform": "translate(" + x + "," + y + ")"
+    });
+    nodeGroup.append("rect")
+        .attr({
+        x: 0,
+        y: 0,
+        width: RECT_SIZE,
+        height: RECT_SIZE
+    });
+    var activeOrNotClass = state[nodeId] ? "active" : "inactive";
+    if (isInput) {
+        var label = INPUTS[nodeId].label != null ?
+            INPUTS[nodeId].label : nodeId;
+        var text = nodeGroup.append("text").attr({
+            class: "main-label",
+            x: -10,
+            y: RECT_SIZE / 2, "text-anchor": "end"
+        });
+        if (/[_^]/.test(label)) {
+            var myRe = /(.*?)([_^])(.)/g;
+            var myArray = void 0;
+            var lastIndex = void 0;
+            while ((myArray = myRe.exec(label)) !== null) {
+                lastIndex = myRe.lastIndex;
+                var prefix = myArray[1];
+                var sep = myArray[2];
+                var suffix = myArray[3];
+                if (prefix) {
+                    text.append("tspan").text(prefix);
+                }
+                text.append("tspan")
+                    .attr("baseline-shift", sep == "_" ? "sub" : "super")
+                    .style("font-size", "9px")
+                    .text(suffix);
+            }
+            if (label.substring(lastIndex)) {
+                text.append("tspan").text(label.substring(lastIndex));
+            }
+        }
+        else {
+            text.append("tspan").text(label);
+        }
+        nodeGroup.classed(activeOrNotClass, true);
+    }
+    if (!isInput) {
+        nodeGroup.append("rect")
+            .attr({
+            id: "bias-" + nodeId,
+            x: -BIAS_SIZE - 2,
+            y: RECT_SIZE - BIAS_SIZE + 3,
+            width: BIAS_SIZE,
+            height: BIAS_SIZE
+        }).on("mouseenter", function () {
+            updateHoverCard(HoverType.BIAS, node, d3.mouse(container.node()));
+        }).on("mouseleave", function () {
+            updateHoverCard(null);
+        });
+    }
+    var div = d3.select("#network").insert("div", ":first-child")
+        .attr({
+        "id": "canvas-" + nodeId,
+        "class": "canvas"
+    })
+        .style({
+        position: "absolute",
+        left: (x + 3) + "px",
+        top: (y + 3) + "px"
+    })
+        .on("mouseenter", function () {
+        selectedNodeId = nodeId;
+        div.classed("hovered", true);
+        nodeGroup.classed("hovered", true);
+        updateDecisionBoundary(network, false);
+        heatMap.updateBackground(boundary[nodeId], state.discretize);
+    })
+        .on("mouseleave", function () {
+        selectedNodeId = null;
+        div.classed("hovered", false);
+        nodeGroup.classed("hovered", false);
+        updateDecisionBoundary(network, false);
+        heatMap.updateBackground(boundary[nn.getOutputNode(network).id], state.discretize);
+    });
+    if (isInput) {
+        div.on("click", function () {
+            state[nodeId] = !state[nodeId];
+            reset();
+        });
+        div.style("cursor", "pointer");
+    }
+    if (isInput) {
+        div.classed(activeOrNotClass, true);
+    }
+    var nodeHeatMap = new heatmap_1.HeatMap(RECT_SIZE, DENSITY / 10, xDomain, xDomain, div, { noSvg: true });
+    div.datum({ heatmap: nodeHeatMap, id: nodeId });
+}
+function drawNetwork(network) {
+    var svg = d3.select("#svg");
+    svg.select("g.core").remove();
+    d3.select("#network").selectAll("div.canvas").remove();
+    d3.select("#network").selectAll("div.plus-minus-neurons").remove();
+    var padding = 3;
+    var co = d3.select(".column.output").node();
+    var cf = d3.select(".column.features").node();
+    var width = co.offsetLeft - cf.offsetLeft;
+    svg.attr("width", width);
+    var node2coord = {};
+    var container = svg.append("g")
+        .classed("core", true)
+        .attr("transform", "translate(" + padding + "," + padding + ")");
+    var numLayers = network.length;
+    var featureWidth = 118;
+    var layerScale = d3.scale.ordinal()
+        .domain(d3.range(1, numLayers - 1))
+        .rangePoints([featureWidth, width - RECT_SIZE], 0.7);
+    var nodeIndexScale = function (nodeIndex) { return nodeIndex * (RECT_SIZE + 25); };
+    var calloutThumb = d3.select(".callout.thumbnail").style("display", "none");
+    var calloutWeights = d3.select(".callout.weights").style("display", "none");
+    var idWithCallout = null;
+    var targetIdWithCallout = null;
+    var cx = RECT_SIZE / 2 + 50;
+    var nodeIds = Object.keys(INPUTS);
+    var maxY = nodeIndexScale(nodeIds.length);
+    nodeIds.forEach(function (nodeId, i) {
+        var cy = nodeIndexScale(i) + RECT_SIZE / 2;
+        node2coord[nodeId] = { cx: cx, cy: cy };
+        drawNode(cx, cy, nodeId, true, container);
+    });
+    for (var layerIdx = 1; layerIdx < numLayers - 1; layerIdx++) {
+        var numNodes = network[layerIdx].length;
+        var cx_1 = layerScale(layerIdx) + RECT_SIZE / 2;
+        maxY = Math.max(maxY, nodeIndexScale(numNodes));
+        addPlusMinusControl(layerScale(layerIdx), layerIdx);
+        for (var i = 0; i < numNodes; i++) {
+            var node_1 = network[layerIdx][i];
+            var cy_1 = nodeIndexScale(i) + RECT_SIZE / 2;
+            node2coord[node_1.id] = { cx: cx_1, cy: cy_1 };
+            drawNode(cx_1, cy_1, node_1.id, false, container, node_1);
+            var numNodes_1 = network[layerIdx].length;
+            var nextNumNodes = network[layerIdx + 1].length;
+            if (idWithCallout == null &&
+                i === numNodes_1 - 1 &&
+                nextNumNodes <= numNodes_1) {
+                calloutThumb.style({
+                    display: null,
+                    top: (20 + 3 + cy_1) + "px",
+                    left: cx_1 + "px"
+                });
+                idWithCallout = node_1.id;
+            }
+            for (var j = 0; j < node_1.inputLinks.length; j++) {
+                var link = node_1.inputLinks[j];
+                var path = drawLink(link, node2coord, network, container, j === 0, j, node_1.inputLinks.length).node();
+                var prevLayer = network[layerIdx - 1];
+                var lastNodePrevLayer = prevLayer[prevLayer.length - 1];
+                if (targetIdWithCallout == null &&
+                    i === numNodes_1 - 1 &&
+                    link.source.id === lastNodePrevLayer.id &&
+                    (link.source.id !== idWithCallout || numLayers <= 5) &&
+                    link.dest.id !== idWithCallout &&
+                    prevLayer.length >= numNodes_1) {
+                    var midPoint = path.getPointAtLength(path.getTotalLength() * 0.7);
+                    calloutWeights.style({
+                        display: null,
+                        top: (midPoint.y + 5) + "px",
+                        left: (midPoint.x + 3) + "px"
+                    });
+                    targetIdWithCallout = link.dest.id;
+                }
+            }
+        }
+    }
+    cx = width + RECT_SIZE / 2;
+    var node = network[numLayers - 1][0];
+    var cy = nodeIndexScale(0) + RECT_SIZE / 2;
+    node2coord[node.id] = { cx: cx, cy: cy };
+    for (var i = 0; i < node.inputLinks.length; i++) {
+        var link = node.inputLinks[i];
+        drawLink(link, node2coord, network, container, i === 0, i, node.inputLinks.length);
+    }
+    svg.attr("height", maxY);
+    var height = Math.max(getRelativeHeight(calloutThumb), getRelativeHeight(calloutWeights), getRelativeHeight(d3.select("#network")));
+    d3.select(".column.features").style("height", height + "px");
+}
+function getRelativeHeight(selection) {
+    var node = selection.node();
+    return node.offsetHeight + node.offsetTop;
+}
+function addPlusMinusControl(x, layerIdx) {
+    var div = d3.select("#network").append("div")
+        .classed("plus-minus-neurons", true)
+        .style("left", (x - 10) + "px");
+    var i = layerIdx - 1;
+    var firstRow = div.append("div").attr("class", "ui-numNodes" + layerIdx);
+    firstRow.append("button")
+        .attr("class", "mdl-button mdl-js-button mdl-button--icon")
+        .on("click", function () {
+        var numNeurons = state.networkShape[i];
+        if (numNeurons >= 8) {
+            return;
+        }
+        state.networkShape[i]++;
+        reset();
+    })
+        .append("i")
+        .attr("class", "material-icons")
+        .text("add");
+    firstRow.append("button")
+        .attr("class", "mdl-button mdl-js-button mdl-button--icon")
+        .on("click", function () {
+        var numNeurons = state.networkShape[i];
+        if (numNeurons <= 1) {
+            return;
+        }
+        state.networkShape[i]--;
+        reset();
+    })
+        .append("i")
+        .attr("class", "material-icons")
+        .text("remove");
+    var suffix = state.networkShape[i] > 1 ? "s" : "";
+    div.append("div").text(state.networkShape[i] + " neuron" + suffix);
+}
+function updateHoverCard(type, nodeOrLink, coordinates) {
+    var hovercard = d3.select("#hovercard");
+    if (type == null) {
+        hovercard.style("display", "none");
+        d3.select("#svg").on("click", null);
+        return;
+    }
+    d3.select("#svg").on("click", function () {
+        hovercard.select(".value").style("display", "none");
+        var input = hovercard.select("input");
+        input.style("display", null);
+        input.on("input", function () {
+            if (this.value != null && this.value !== "") {
+                if (type == HoverType.WEIGHT) {
+                    nodeOrLink.weight = +this.value;
+                }
+                else {
+                    nodeOrLink.bias = +this.value;
+                }
+                updateUI();
+            }
+        });
+        input.on("keypress", function () {
+            if (d3.event.keyCode == 13) {
+                updateHoverCard(type, nodeOrLink, coordinates);
+            }
+        });
+        input.node().focus();
+    });
+    var value = type == HoverType.WEIGHT ?
+        nodeOrLink.weight :
+        nodeOrLink.bias;
+    var name = type == HoverType.WEIGHT ? "Weight" : "Bias";
+    hovercard.style({
+        "left": (coordinates[0] + 20) + "px",
+        "top": coordinates[1] + "px",
+        "display": "block"
+    });
+    hovercard.select(".type").text(name);
+    hovercard.select(".value")
+        .style("display", null)
+        .text(value.toPrecision(2));
+    hovercard.select("input")
+        .property("value", value.toPrecision(2))
+        .style("display", "none");
+}
+function drawLink(input, node2coord, network, container, isFirst, index, length) {
+    var line = container.insert("path", ":first-child");
+    var source = node2coord[input.source.id];
+    var dest = node2coord[input.dest.id];
+    var datum = {
+        source: {
+            y: source.cx + RECT_SIZE / 2 + 2,
+            x: source.cy
+        },
+        target: {
+            y: dest.cx - RECT_SIZE / 2,
+            x: dest.cy + ((index - (length - 1) / 2) / length) * 12
+        }
+    };
+    var diagonal = d3.svg.diagonal().projection(function (d) { return [d.y, d.x]; });
+    line.attr({
+        "marker-start": "url(#markerArrow)",
+        class: "link",
+        id: "link" + input.source.id + "-" + input.dest.id,
+        d: diagonal(datum, 0)
+    });
+    container.append("path")
+        .attr("d", diagonal(datum, 0))
+        .attr("class", "link-hover")
+        .on("mouseenter", function () {
+        updateHoverCard(HoverType.WEIGHT, input, d3.mouse(this));
+    }).on("mouseleave", function () {
+        updateHoverCard(null);
+    });
+    return line;
+}
+function updateDecisionBoundary(network, firstTime) {
+    if (firstTime) {
+        boundary = {};
+        nn.forEachNode(network, true, function (node) {
+            boundary[node.id] = new Array(DENSITY);
+        });
+        for (var nodeId in INPUTS) {
+            boundary[nodeId] = new Array(DENSITY);
+        }
+    }
+    var xScale = d3.scale.linear().domain([0, DENSITY - 1]).range(xDomain);
+    var yScale = d3.scale.linear().domain([DENSITY - 1, 0]).range(xDomain);
+    var i = 0, j = 0;
+    for (i = 0; i < DENSITY; i++) {
+        if (firstTime) {
+            nn.forEachNode(network, true, function (node) {
+                boundary[node.id][i] = new Array(DENSITY);
+            });
+            for (var nodeId in INPUTS) {
+                boundary[nodeId][i] = new Array(DENSITY);
+            }
+        }
+        for (j = 0; j < DENSITY; j++) {
+            var x = xScale(i);
+            var y = yScale(j);
+            var input = constructInput(x, y);
+            nn.forwardProp(network, input);
+            nn.forEachNode(network, true, function (node) {
+                boundary[node.id][i][j] = node.output;
+            });
+            if (firstTime) {
+                for (var nodeId in INPUTS) {
+                    boundary[nodeId][i][j] = INPUTS[nodeId].f(x, y);
+                }
+            }
+        }
+    }
+}
+function getLoss(network, dataPoints) {
+    var loss = 0;
+    for (var i = 0; i < dataPoints.length; i++) {
+        var dataPoint = dataPoints[i];
+        var input = constructInput(dataPoint.x, dataPoint.y);
+        var output = nn.forwardProp(network, input);
+        loss += nn.Errors.SQUARE.error(output, dataPoint.label);
+    }
+    return loss / dataPoints.length;
+}
+function updateUI(firstStep) {
+    if (firstStep === void 0) { firstStep = false; }
+    updateWeightsUI(network, d3.select("g.core"));
+    updateBiasesUI(network);
+    updateDecisionBoundary(network, firstStep);
+    var selectedId = selectedNodeId != null ?
+        selectedNodeId : nn.getOutputNode(network).id;
+    heatMap.updateBackground(boundary[selectedId], state.discretize);
+    d3.select("#network").selectAll("div.canvas")
+        .each(function (data) {
+        data.heatmap.updateBackground(heatmap_1.reduceMatrix(boundary[data.id], 10), state.discretize);
+    });
+    function zeroPad(n) {
+        var pad = "000000";
+        return (pad + n).slice(-pad.length);
+    }
+    function addCommas(s) {
+        return s.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    }
+    function humanReadable(n) {
+        return n.toFixed(3);
+    }
+    d3.select("#loss-train").text(humanReadable(lossTrain));
+    d3.select("#loss-test").text(humanReadable(lossTest));
+    d3.select("#iter-number").text(addCommas(zeroPad(iter)));
+    lineChart.addDataPoint([lossTrain, lossTest]);
+}
+function constructInputIds() {
+    var result = [];
+    for (var inputName in INPUTS) {
+        if (state[inputName]) {
+            result.push(inputName);
+        }
+    }
+    return result;
+}
+function constructInput(x, y) {
+    var input = [];
+    for (var inputName in INPUTS) {
+        if (state[inputName]) {
+            input.push(INPUTS[inputName].f(x, y));
+        }
+    }
+    return input;
+}
+function oneStep() {
+    iter++;
+    trainData.forEach(function (point, i) {
+        var input = constructInput(point.x, point.y);
+        nn.forwardProp(network, input);
+        nn.backProp(network, point.label, nn.Errors.SQUARE);
+        if ((i + 1) % state.batchSize === 0) {
+            nn.updateWeights(network, state.learningRate, state.regularizationRate);
+        }
+    });
+    lossTrain = getLoss(network, trainData);
+    lossTest = getLoss(network, testData);
+    updateUI();
+}
+function getOutputWeights(network) {
+    var weights = [];
+    for (var layerIdx = 0; layerIdx < network.length - 1; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            for (var j = 0; j < node.outputs.length; j++) {
+                var output = node.outputs[j];
+                weights.push(output.weight);
+            }
+        }
+    }
+    return weights;
+}
+exports.getOutputWeights = getOutputWeights;
+function setOutputWeights(network, weights) {
+    var idx = 0;
+    for (var layerIdx = 0; layerIdx < network.length - 1; layerIdx++) {
+        var currentLayer = network[layerIdx];
+        for (var i = 0; i < currentLayer.length; i++) {
+            var node = currentLayer[i];
+            for (var j = 0; j < node.outputs.length; j++) {
+                node.outputs[j].weight = weights[idx++];
+            }
+        }
+    }
+}
+function reset() {
+    lineChart.reset();
+    state.serialize();
+    player.pause();
+    var suffix = state.numHiddenLayers !== 1 ? "s" : "";
+    d3.select("#layers-label").text("Hidden layer" + suffix);
+    d3.select("#num-layers").text(state.numHiddenLayers);
+    iter = 0;
+    var numInputs = constructInput(0, 0).length;
+    var shape = [numInputs].concat(state.networkShape).concat([1]);
+    var outputActivation = (state.problem == state_1.Problem.REGRESSION) ?
+        nn.Activations.LINEAR : nn.Activations.TANH;
+    network = nn.buildNetwork(shape, state.activation, outputActivation, state.regularization, constructInputIds());
+    lossTrain = getLoss(network, trainData);
+    lossTest = getLoss(network, testData);
+    drawNetwork(network);
+    updateUI(true);
+}
+;
+function updateActivation() {
+    state.serialize();
+    var numInputs = constructInput(0, 0).length;
+    var shape = [numInputs].concat(state.networkShape).concat([1]);
+    var outputActivation = (state.problem == state_1.Problem.REGRESSION) ?
+        nn.Activations.LINEAR : nn.Activations.TANH;
+    var weights = getOutputWeights(network);
+    network = nn.buildNetwork(shape, state.activation, outputActivation, state.regularization, constructInputIds());
+    setOutputWeights(network, weights);
+}
+;
+function initTutorial() {
+    if (state.tutorial == null) {
+        return;
+    }
+    d3.selectAll("article div.l--body").remove();
+    var tutorial = d3.select("article").append("div")
+        .attr("class", "l--body");
+    d3.html("tutorials/" + state.tutorial + ".html", function (err, htmlFragment) {
+        if (err) {
+            throw err;
+        }
+        tutorial.node().appendChild(htmlFragment);
+        var title = tutorial.select("title");
+        if (title.size()) {
+            d3.select("header h1").style({
+                "margin-top": "20px",
+                "margin-bottom": "20px"
+            })
+                .text(title.text());
+            document.title = title.text();
+        }
+    });
+}
+function drawDatasetThumbnails() {
+    function renderThumbnail(canvas, dataGenerator) {
+        var w = 100;
+        var h = 100;
+        canvas.setAttribute("width", w);
+        canvas.setAttribute("height", h);
+        var context = canvas.getContext("2d");
+        var data = dataGenerator(200, 0);
+        data.forEach(function (d) {
+            context.fillStyle = colorScale(d.label);
+            context.fillRect(w * (d.x + 6) / 12, h * (d.y + 6) / 12, 4, 4);
+        });
+        d3.select(canvas.parentNode).style("display", null);
+    }
+    d3.selectAll(".dataset").style("display", "none");
+    if (state.problem == state_1.Problem.CLASSIFICATION) {
+        for (var dataset in state_1.datasets) {
+            var canvas = document.querySelector("canvas[data-dataset=" + dataset + "]");
+            var dataGenerator = state_1.datasets[dataset];
+            renderThumbnail(canvas, dataGenerator);
+        }
+    }
+    if (state.problem == state_1.Problem.REGRESSION) {
+        for (var regDataset in state_1.regDatasets) {
+            var canvas = document.querySelector("canvas[data-regDataset=" + regDataset + "]");
+            var dataGenerator = state_1.regDatasets[regDataset];
+            renderThumbnail(canvas, dataGenerator);
+        }
+    }
+}
+function hideControls() {
+    var hiddenProps = state.getHiddenProps();
+    hiddenProps.forEach(function (prop) {
+        var controls = d3.selectAll(".ui-" + prop);
+        if (controls.size() == 0) {
+            console.warn("0 html elements found with class .ui-" + prop);
+        }
+        controls.style("display", "none");
+    });
+    var hideControls = d3.select(".hide-controls");
+    HIDABLE_CONTROLS.forEach(function (_a) {
+        var text = _a[0], id = _a[1];
+        var label = hideControls.append("label")
+            .attr("class", "mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect");
+        var input = label.append("input")
+            .attr({
+            type: "checkbox",
+            class: "mdl-checkbox__input"
+        });
+        if (hiddenProps.indexOf(id) == -1) {
+            input.attr("checked", "true");
+        }
+        input.on("change", function () {
+            state.setHideProperty(id, !this.checked);
+            state.serialize();
+            d3.select(".hide-controls-link")
+                .attr("href", window.location.href);
+        });
+        label.append("span")
+            .attr("class", "mdl-checkbox__label label")
+            .text(text);
+    });
+    d3.select(".hide-controls-link")
+        .attr("href", window.location.href);
+}
+function generateData(firstTime) {
+    if (firstTime === void 0) { firstTime = false; }
+    if (!firstTime) {
+        state.seed = Math.random().toFixed(5);
+        state.serialize();
+    }
+    Math.seedrandom(state.seed);
+    var numSamples = (state.problem == state_1.Problem.REGRESSION) ?
+        NUM_SAMPLES_REGRESS : NUM_SAMPLES_CLASSIFY;
+    var generator = state.problem == state_1.Problem.CLASSIFICATION ?
+        state.dataset : state.regDataset;
+    var data = generator(numSamples, state.noise / 100);
+    dataset_1.shuffle(data);
+    var splitIndex = Math.floor(data.length * state.percTrainData / 100);
+    trainData = data.slice(0, splitIndex);
+    testData = data.slice(splitIndex);
+    heatMap.updatePoints(trainData);
+    heatMap.updateTestPoints(state.showTestData ? testData : []);
+}
+drawDatasetThumbnails();
+initTutorial();
+makeGUI();
+generateData(true);
+reset();
+hideControls();
+
+},{"./dataset":1,"./heatmap":2,"./linechart":3,"./nn":4,"./state":6}],6:[function(require,module,exports){
+"use strict";
+var nn = require("./nn");
+var dataset = require("./dataset");
+var HIDE_STATE_SUFFIX = "_hide";
+exports.activations = {
+    "arctan": nn.Activations.ARCTAN,
+    "bent": nn.Activations.BENT,
+    "elu": nn.Activations.ELU,
+    "gaussian": nn.Activations.GAUSSIAN,
+    "linear": nn.Activations.LINEAR,
+    "relu": nn.Activations.RELU,
+    "sigmoid": nn.Activations.SIGMOID,
+    "sin": nn.Activations.SINUSOID,
+    "softplus": nn.Activations.SOFTPLUS,
+    "softsign": nn.Activations.SOFTSIGN,
+    "tanh": nn.Activations.TANH
+};
+exports.regularizations = {
+    "none": null,
+    "L1": nn.RegularizationFunction.L1,
+    "L2": nn.RegularizationFunction.L2
+};
+exports.datasets = {
+    "circle": dataset.classifyCircleData,
+    "xor": dataset.classifyXORData,
+    "gauss": dataset.classifyTwoGaussData,
+    "spiral": dataset.classifySpiralData
+};
+exports.regDatasets = {
+    "reg-plane": dataset.regressPlane,
+    "reg-gauss": dataset.regressGaussian
+};
+function getKeyFromValue(obj, value) {
+    for (var key in obj) {
+        if (obj[key] === value) {
+            return key;
+        }
+    }
+    return undefined;
+}
+exports.getKeyFromValue = getKeyFromValue;
+function endsWith(s, suffix) {
+    return s.substr(-suffix.length) === suffix;
+}
+function getHideProps(obj) {
+    var result = [];
+    for (var prop in obj) {
+        if (endsWith(prop, HIDE_STATE_SUFFIX)) {
+            result.push(prop);
+        }
+    }
+    return result;
+}
+(function (Type) {
+    Type[Type["STRING"] = 0] = "STRING";
+    Type[Type["NUMBER"] = 1] = "NUMBER";
+    Type[Type["ARRAY_NUMBER"] = 2] = "ARRAY_NUMBER";
+    Type[Type["ARRAY_STRING"] = 3] = "ARRAY_STRING";
+    Type[Type["BOOLEAN"] = 4] = "BOOLEAN";
+    Type[Type["OBJECT"] = 5] = "OBJECT";
+})(exports.Type || (exports.Type = {}));
+var Type = exports.Type;
+(function (Problem) {
+    Problem[Problem["CLASSIFICATION"] = 0] = "CLASSIFICATION";
+    Problem[Problem["REGRESSION"] = 1] = "REGRESSION";
+})(exports.Problem || (exports.Problem = {}));
+var Problem = exports.Problem;
+exports.problems = {
+    "classification": Problem.CLASSIFICATION,
+    "regression": Problem.REGRESSION
+};
+;
+var State = (function () {
+    function State() {
+        this.learningRate = 0.03;
+        this.regularizationRate = 0;
+        this.showTestData = false;
+        this.noise = 0;
+        this.batchSize = 10;
+        this.discretize = false;
+        this.tutorial = null;
+        this.percTrainData = 50;
+        this.activation = nn.Activations.TANH;
+        this.regularization = null;
+        this.problem = Problem.CLASSIFICATION;
+        this.collectStats = false;
+        this.numHiddenLayers = 1;
+        this.hiddenLayerControls = [];
+        this.networkShape = [4, 2];
+        this.x = true;
+        this.y = true;
+        this.xTimesY = false;
+        this.xSquared = false;
+        this.ySquared = false;
+        this.cosX = false;
+        this.sinX = false;
+        this.cosY = false;
+        this.sinY = false;
+        this.dataset = dataset.classifyCircleData;
+        this.regDataset = dataset.regressPlane;
+    }
+    State.deserializeState = function () {
+        var map = {};
+        for (var _i = 0, _a = window.location.hash.slice(1).split("&"); _i < _a.length; _i++) {
+            var keyvalue = _a[_i];
+            var _b = keyvalue.split("="), name_1 = _b[0], value = _b[1];
+            map[name_1] = value;
+        }
+        var state = new State();
+        function hasKey(name) {
+            return name in map && map[name] != null && map[name].trim() !== "";
+        }
+        function parseArray(value) {
+            return value.trim() === "" ? [] : value.split(",");
+        }
+        State.PROPS.forEach(function (_a) {
+            var name = _a.name, type = _a.type, keyMap = _a.keyMap;
+            switch (type) {
+                case Type.OBJECT:
+                    if (keyMap == null) {
+                        throw Error("A key-value map must be provided for state " +
+                            "variables of type Object");
+                    }
+                    if (hasKey(name) && map[name] in keyMap) {
+                        state[name] = keyMap[map[name]];
+                    }
+                    break;
+                case Type.NUMBER:
+                    if (hasKey(name)) {
+                        state[name] = +map[name];
+                    }
+                    break;
+                case Type.STRING:
+                    if (hasKey(name)) {
+                        state[name] = map[name];
+                    }
+                    break;
+                case Type.BOOLEAN:
+                    if (hasKey(name)) {
+                        state[name] = (map[name] === "false" ? false : true);
+                    }
+                    break;
+                case Type.ARRAY_NUMBER:
+                    if (name in map) {
+                        state[name] = parseArray(map[name]).map(Number);
+                    }
+                    break;
+                case Type.ARRAY_STRING:
+                    if (name in map) {
+                        state[name] = parseArray(map[name]);
+                    }
+                    break;
+                default:
+                    throw Error("Encountered an unknown type for a state variable");
+            }
+        });
+        getHideProps(map).forEach(function (prop) {
+            state[prop] = (map[prop] === "true") ? true : false;
+        });
+        state.numHiddenLayers = state.networkShape.length;
+        if (state.seed == null) {
+            state.seed = Math.random().toFixed(5);
+        }
+        Math.seedrandom(state.seed);
+        return state;
+    };
+    State.prototype.serialize = function () {
+        var _this = this;
+        var props = [];
+        State.PROPS.forEach(function (_a) {
+            var name = _a.name, type = _a.type, keyMap = _a.keyMap;
+            var value = _this[name];
+            if (value == null) {
+                return;
+            }
+            if (type === Type.OBJECT) {
+                value = getKeyFromValue(keyMap, value);
+            }
+            else if (type === Type.ARRAY_NUMBER ||
+                type === Type.ARRAY_STRING) {
+                value = value.join(",");
+            }
+            props.push(name + "=" + value);
+        });
+        getHideProps(this).forEach(function (prop) {
+            props.push(prop + "=" + _this[prop]);
+        });
+        window.location.hash = props.join("&");
+    };
+    State.prototype.getHiddenProps = function () {
+        var result = [];
+        for (var prop in this) {
+            if (endsWith(prop, HIDE_STATE_SUFFIX) && this[prop] === true) {
+                result.push(prop.replace(HIDE_STATE_SUFFIX, ""));
+            }
+        }
+        return result;
+    };
+    State.prototype.setHideProperty = function (name, hidden) {
+        this[name + HIDE_STATE_SUFFIX] = hidden;
+    };
+    State.PROPS = [
+        { name: "activation", type: Type.OBJECT, keyMap: exports.activations },
+        { name: "regularization", type: Type.OBJECT, keyMap: exports.regularizations },
+        { name: "batchSize", type: Type.NUMBER },
+        { name: "dataset", type: Type.OBJECT, keyMap: exports.datasets },
+        { name: "regDataset", type: Type.OBJECT, keyMap: exports.regDatasets },
+        { name: "learningRate", type: Type.NUMBER },
+        { name: "regularizationRate", type: Type.NUMBER },
+        { name: "noise", type: Type.NUMBER },
+        { name: "networkShape", type: Type.ARRAY_NUMBER },
+        { name: "seed", type: Type.STRING },
+        { name: "showTestData", type: Type.BOOLEAN },
+        { name: "discretize", type: Type.BOOLEAN },
+        { name: "percTrainData", type: Type.NUMBER },
+        { name: "x", type: Type.BOOLEAN },
+        { name: "y", type: Type.BOOLEAN },
+        { name: "xTimesY", type: Type.BOOLEAN },
+        { name: "xSquared", type: Type.BOOLEAN },
+        { name: "ySquared", type: Type.BOOLEAN },
+        { name: "cosX", type: Type.BOOLEAN },
+        { name: "sinX", type: Type.BOOLEAN },
+        { name: "cosY", type: Type.BOOLEAN },
+        { name: "sinY", type: Type.BOOLEAN },
+        { name: "collectStats", type: Type.BOOLEAN },
+        { name: "tutorial", type: Type.STRING },
+        { name: "problem", type: Type.OBJECT, keyMap: exports.problems }
+    ];
+    return State;
+}());
+exports.State = State;
+
+},{"./dataset":1,"./nn":4}]},{},[5])
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm5vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJkYXRhc2V0LnRzIiwiaGVhdG1hcC50cyIsImxpbmVjaGFydC50cyIsIm5uLnRzIiwicGxheWdyb3VuZC50cyIsInN0YXRlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBOztBQ2lDQSxpQkFBd0IsS0FBWTtJQUNsQyxJQUFJLE9BQU8sR0FBRyxLQUFLLENBQUMsTUFBTSxDQUFDO0lBQzNCLElBQUksSUFBSSxHQUFHLENBQUMsQ0FBQztJQUNiLElBQUksS0FBSyxHQUFHLENBQUMsQ0FBQztJQUVkLE9BQU8sT0FBTyxHQUFHLENBQUMsRUFBRSxDQUFDO1FBRW5CLEtBQUssR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLEVBQUUsR0FBRyxPQUFPLENBQUMsQ0FBQztRQUU1QyxPQUFPLEVBQUUsQ0FBQztRQUVWLElBQUksR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDdEIsS0FBSyxDQUFDLE9BQU8sQ0FBQyxHQUFHLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUM5QixLQUFLLENBQUMsS0FBSyxDQUFDLEdBQUcsSUFBSSxDQUFDO0lBQ3RCLENBQUM7QUFDSCxDQUFDO0FBZmUsZUFBTyxVQWV0QixDQUFBO0FBSUQsOEJBQXFDLFVBQWtCLEVBQUUsS0FBYTtJQUVwRSxJQUFJLE1BQU0sR0FBZ0IsRUFBRSxDQUFDO0lBRTdCLElBQUksYUFBYSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDdEUsSUFBSSxRQUFRLEdBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBRXBDLGtCQUFrQixFQUFVLEVBQUUsRUFBVSxFQUFFLEtBQWE7UUFDckQsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxVQUFVLEdBQUcsQ0FBQyxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDeEMsSUFBSSxDQUFDLEdBQUcsWUFBWSxDQUFDLEVBQUUsRUFBRSxRQUFRLENBQUMsQ0FBQztZQUNuQyxJQUFJLENBQUMsR0FBRyxZQUFZLENBQUMsRUFBRSxFQUFFLFFBQVEsQ0FBQyxDQUFDO1lBQ25DLE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBQyxDQUFDLENBQUM7UUFDMUMsQ0FBQztJQUNILENBQUM7SUFFRCxRQUFRLENBQUMsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUNsQixRQUFRLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNyQixNQUFNLENBQUMsTUFBTSxDQUFDO0FBQ2hCLENBQUM7QUFsQmUsNEJBQW9CLHVCQWtCbkMsQ0FBQTtBQUVELHNCQUE2QixVQUFrQixFQUFFLEtBQWE7SUFFNUQsSUFBSSxNQUFNLEdBQUcsQ0FBQyxDQUFDO0lBQ2YsSUFBSSxVQUFVLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUU7U0FDL0IsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUFDLENBQUM7U0FDakIsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNsQixJQUFJLFFBQVEsR0FBRyxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxVQUFVLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFqQixDQUFpQixDQUFDO0lBRTNDLElBQUksTUFBTSxHQUFnQixFQUFFLENBQUM7SUFDN0IsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxVQUFVLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztRQUNwQyxJQUFJLENBQUMsR0FBRyxXQUFXLENBQUMsQ0FBQyxNQUFNLEVBQUUsTUFBTSxDQUFDLENBQUM7UUFDckMsSUFBSSxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDO1FBQ3JDLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDbEQsSUFBSSxNQUFNLEdBQUcsV0FBVyxDQUFDLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxHQUFHLEtBQUssQ0FBQztRQUNsRCxJQUFJLEtBQUssR0FBRyxRQUFRLENBQUMsQ0FBQyxHQUFHLE1BQU0sRUFBRSxDQUFDLEdBQUcsTUFBTSxDQUFDLENBQUM7UUFDN0MsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFDLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBbEJlLG9CQUFZLGVBa0IzQixDQUFBO0FBRUQseUJBQWdDLFVBQWtCLEVBQUUsS0FBYTtJQUUvRCxJQUFJLE1BQU0sR0FBZ0IsRUFBRSxDQUFDO0lBRTdCLElBQUksVUFBVSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFO1NBQy9CLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztTQUNkLEtBQUssQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztTQUNiLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUVmLElBQUksU0FBUyxHQUFHO1FBQ2QsQ0FBQyxDQUFDLENBQUMsRUFBRSxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQ1osQ0FBQyxDQUFDLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQ1osQ0FBQyxDQUFDLEVBQUUsR0FBRyxFQUFFLENBQUMsQ0FBQztRQUNYLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDZCxDQUFDLENBQUMsRUFBRSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7UUFDWixDQUFDLENBQUMsRUFBRSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUMsQ0FBQztLQUNkLENBQUM7SUFFRixrQkFBa0IsQ0FBQyxFQUFFLENBQUM7UUFFcEIsSUFBSSxLQUFLLEdBQUcsQ0FBQyxDQUFDO1FBQ2QsU0FBUyxDQUFDLE9BQU8sQ0FBQyxVQUFDLEVBQWM7Z0JBQWIsVUFBRSxFQUFFLFVBQUUsRUFBRSxZQUFJO1lBQzlCLElBQUksUUFBUSxHQUFHLElBQUksR0FBRyxVQUFVLENBQUMsSUFBSSxDQUFDLEVBQUMsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFDLEVBQUUsRUFBQyxDQUFDLEVBQUUsRUFBRSxFQUFFLENBQUMsRUFBRSxFQUFFLEVBQUMsQ0FBQyxDQUFDLENBQUM7WUFDckUsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxRQUFRLENBQUMsR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDekMsS0FBSyxHQUFHLFFBQVEsQ0FBQztZQUNuQixDQUFDO1FBQ0gsQ0FBQyxDQUFDLENBQUM7UUFDSCxNQUFNLENBQUMsS0FBSyxDQUFDO0lBQ2YsQ0FBQztJQUNELElBQUksTUFBTSxHQUFHLENBQUMsQ0FBQztJQUNmLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsVUFBVSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDcEMsSUFBSSxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDO1FBQ3JDLElBQUksQ0FBQyxHQUFHLFdBQVcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUMsQ0FBQztRQUNyQyxJQUFJLE1BQU0sR0FBRyxXQUFXLENBQUMsQ0FBQyxNQUFNLEVBQUUsTUFBTSxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ2xELElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDbEQsSUFBSSxLQUFLLEdBQUcsUUFBUSxDQUFDLENBQUMsR0FBRyxNQUFNLEVBQUUsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxDQUFDO1FBQzdDLE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBQyxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUFBLENBQUM7SUFDRixNQUFNLENBQUMsTUFBTSxDQUFDO0FBQ2hCLENBQUM7QUF2Q2UsdUJBQWUsa0JBdUM5QixDQUFBO0FBRUQsNEJBQW1DLFVBQWtCLEVBQUUsS0FBYTtJQUVsRSxJQUFJLE1BQU0sR0FBZ0IsRUFBRSxDQUFDO0lBQzdCLElBQUksQ0FBQyxHQUFHLFVBQVUsR0FBRyxDQUFDLENBQUM7SUFFdkIsbUJBQW1CLE1BQWMsRUFBRSxLQUFhO1FBQzlDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDM0IsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLENBQUM7WUFDbEIsSUFBSSxDQUFDLEdBQUcsSUFBSSxHQUFHLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxFQUFFLEdBQUcsTUFBTSxDQUFDO1lBQzVDLElBQUksQ0FBQyxHQUFHLENBQUMsR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLFdBQVcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsR0FBRyxLQUFLLENBQUM7WUFDckQsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxHQUFHLEtBQUssQ0FBQztZQUNyRCxNQUFNLENBQUMsSUFBSSxDQUFDLEVBQUMsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFFLEtBQUssRUFBRSxLQUFLLEVBQUMsQ0FBQyxDQUFDO1FBQzFDLENBQUM7SUFDSCxDQUFDO0lBRUQsU0FBUyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUNoQixTQUFTLENBQUMsSUFBSSxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3ZCLE1BQU0sQ0FBQyxNQUFNLENBQUM7QUFDaEIsQ0FBQztBQWxCZSwwQkFBa0IscUJBa0JqQyxDQUFBO0FBRUQsNEJBQW1DLFVBQWtCLEVBQUUsS0FBYTtJQUVsRSxJQUFJLE1BQU0sR0FBZ0IsRUFBRSxDQUFDO0lBQzdCLElBQUksTUFBTSxHQUFHLENBQUMsQ0FBQztJQUNmLHdCQUF3QixDQUFRLEVBQUUsTUFBYTtRQUM3QyxNQUFNLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxFQUFFLE1BQU0sQ0FBQyxHQUFHLENBQUMsTUFBTSxHQUFHLEdBQUcsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDO0lBQ3JELENBQUM7SUFHRCxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLFVBQVUsR0FBRyxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztRQUN4QyxJQUFJLENBQUMsR0FBRyxXQUFXLENBQUMsQ0FBQyxFQUFFLE1BQU0sR0FBRyxHQUFHLENBQUMsQ0FBQztRQUNyQyxJQUFJLEtBQUssR0FBRyxXQUFXLENBQUMsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLENBQUMsRUFBRSxDQUFDLENBQUM7UUFDeEMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDNUIsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDNUIsSUFBSSxNQUFNLEdBQUcsV0FBVyxDQUFDLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxHQUFHLEtBQUssQ0FBQztRQUNsRCxJQUFJLE1BQU0sR0FBRyxXQUFXLENBQUMsQ0FBQyxNQUFNLEVBQUUsTUFBTSxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ2xELElBQUksS0FBSyxHQUFHLGNBQWMsQ0FBQyxFQUFDLENBQUMsRUFBRSxDQUFDLEdBQUcsTUFBTSxFQUFFLENBQUMsRUFBRSxDQUFDLEdBQUcsTUFBTSxFQUFDLEVBQUUsRUFBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUMsQ0FBQyxDQUFDO1FBQ3pFLE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBQyxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUdELEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsVUFBVSxHQUFHLENBQUMsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQ3hDLElBQUksQ0FBQyxHQUFHLFdBQVcsQ0FBQyxNQUFNLEdBQUcsR0FBRyxFQUFFLE1BQU0sQ0FBQyxDQUFDO1FBQzFDLElBQUksS0FBSyxHQUFHLFdBQVcsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxHQUFHLElBQUksQ0FBQyxFQUFFLENBQUMsQ0FBQztRQUN4QyxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUM1QixJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUM1QixJQUFJLE1BQU0sR0FBRyxXQUFXLENBQUMsQ0FBQyxNQUFNLEVBQUUsTUFBTSxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ2xELElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDbEQsSUFBSSxLQUFLLEdBQUcsY0FBYyxDQUFDLEVBQUMsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFNLEVBQUUsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFNLEVBQUMsRUFBRSxFQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBQyxDQUFDLENBQUM7UUFDekUsTUFBTSxDQUFDLElBQUksQ0FBQyxFQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFDLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBaENlLDBCQUFrQixxQkFnQ2pDLENBQUE7QUFFRCx5QkFBZ0MsVUFBa0IsRUFBRSxLQUFhO0lBRS9ELHFCQUFxQixDQUFRLElBQUksTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUVsRSxJQUFJLE1BQU0sR0FBZ0IsRUFBRSxDQUFDO0lBQzdCLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsVUFBVSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDcEMsSUFBSSxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQzNCLElBQUksT0FBTyxHQUFHLEdBQUcsQ0FBQztRQUNsQixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsR0FBRyxPQUFPLEdBQUcsQ0FBQyxPQUFPLENBQUM7UUFDaEMsSUFBSSxDQUFDLEdBQUcsV0FBVyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQzNCLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLE9BQU8sR0FBRyxDQUFDLE9BQU8sQ0FBQztRQUNoQyxJQUFJLE1BQU0sR0FBRyxXQUFXLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ3hDLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDeEMsSUFBSSxLQUFLLEdBQUcsV0FBVyxDQUFDLEVBQUMsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFNLEVBQUUsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFNLEVBQUMsQ0FBQyxDQUFDO1FBQ3hELE1BQU0sQ0FBQyxJQUFJLENBQUMsRUFBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsRUFBRSxDQUFDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBQyxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUNELE1BQU0sQ0FBQyxNQUFNLENBQUM7QUFDaEIsQ0FBQztBQWpCZSx1QkFBZSxrQkFpQjlCLENBQUE7QUFNRCxxQkFBcUIsQ0FBUyxFQUFFLENBQVM7SUFDdkMsTUFBTSxDQUFDLElBQUksQ0FBQyxNQUFNLEVBQUUsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUM7QUFDckMsQ0FBQztBQVNELHNCQUFzQixJQUFRLEVBQUUsUUFBWTtJQUF0QixvQkFBUSxHQUFSLFFBQVE7SUFBRSx3QkFBWSxHQUFaLFlBQVk7SUFDMUMsSUFBSSxFQUFVLEVBQUUsRUFBVSxFQUFFLENBQVMsQ0FBQztJQUN0QyxHQUFHLENBQUM7UUFDRixFQUFFLEdBQUcsQ0FBQyxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsR0FBRyxDQUFDLENBQUM7UUFDM0IsRUFBRSxHQUFHLENBQUMsR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEdBQUcsQ0FBQyxDQUFDO1FBQzNCLENBQUMsR0FBRyxFQUFFLEdBQUcsRUFBRSxHQUFHLEVBQUUsR0FBRyxFQUFFLENBQUM7SUFDeEIsQ0FBQyxRQUFRLENBQUMsR0FBRyxDQUFDLEVBQUU7SUFFaEIsSUFBSSxNQUFNLEdBQUcsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUNsRCxNQUFNLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEdBQUcsTUFBTSxDQUFDO0FBQzdDLENBQUM7QUFHRCxjQUFjLENBQVEsRUFBRSxDQUFRO0lBQzlCLElBQUksRUFBRSxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNuQixJQUFJLEVBQUUsR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDbkIsTUFBTSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsRUFBRSxHQUFHLEVBQUUsR0FBRyxFQUFFLEdBQUcsRUFBRSxDQUFDLENBQUM7QUFDdEMsQ0FBQzs7OztBQ3RORCxJQUFNLFVBQVUsR0FBRyxFQUFFLENBQUM7QUFPdEI7SUFZRSxpQkFDSSxLQUFhLEVBQUUsVUFBa0IsRUFBRSxPQUF5QixFQUM1RCxPQUF5QixFQUFFLFNBQTRCLEVBQ3ZELFlBQThCO1FBZDFCLGFBQVEsR0FBb0I7WUFDbEMsUUFBUSxFQUFFLEtBQUs7WUFDZixLQUFLLEVBQUUsS0FBSztTQUNiLENBQUM7UUFZQSxJQUFJLENBQUMsVUFBVSxHQUFHLFVBQVUsQ0FBQztRQUM3QixJQUFJLE1BQU0sR0FBRyxLQUFLLENBQUM7UUFDbkIsSUFBSSxPQUFPLEdBQUcsWUFBWSxDQUFDLFFBQVEsR0FBRyxFQUFFLEdBQUcsQ0FBQyxDQUFDO1FBRTdDLEVBQUUsQ0FBQyxDQUFDLFlBQVksSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDO1lBRXpCLEdBQUcsQ0FBQyxDQUFDLElBQUksSUFBSSxJQUFJLFlBQVksQ0FBQyxDQUFDLENBQUM7Z0JBQzlCLElBQUksQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEdBQUcsWUFBWSxDQUFDLElBQUksQ0FBQyxDQUFDO1lBQzNDLENBQUM7UUFDSCxDQUFDO1FBRUQsSUFBSSxDQUFDLE1BQU0sR0FBRyxFQUFFLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRTthQUM1QixNQUFNLENBQUMsT0FBTyxDQUFDO2FBQ2YsS0FBSyxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssR0FBRyxDQUFDLEdBQUcsT0FBTyxDQUFDLENBQUMsQ0FBQztRQUVuQyxJQUFJLENBQUMsTUFBTSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFO2FBQzVCLE1BQU0sQ0FBQyxPQUFPLENBQUM7YUFDZixLQUFLLENBQUMsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxHQUFHLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBR3BDLElBQUksUUFBUSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFrQjthQUMzQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUUsRUFBRSxFQUFFLENBQUMsQ0FBQyxDQUFDO2FBQ2xCLEtBQUssQ0FBQyxDQUFDLFNBQVMsRUFBRSxTQUFTLEVBQUUsU0FBUyxDQUFDLENBQUM7YUFDeEMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO1FBS2pCLElBQUksTUFBTSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLEVBQUUsQ0FBQyxHQUFHLFVBQVUsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxVQUFBLENBQUM7WUFDdEQsTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyQixDQUFDLENBQUMsQ0FBQztRQUNILElBQUksQ0FBQyxLQUFLLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQVU7YUFDdEIsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7YUFDZixLQUFLLENBQUMsTUFBTSxDQUFDLENBQUM7UUFFaEMsU0FBUyxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDO2FBQ2hDLEtBQUssQ0FBQztZQUNMLEtBQUssRUFBSyxLQUFLLE9BQUk7WUFDbkIsTUFBTSxFQUFLLE1BQU0sT0FBSTtZQUNyQixRQUFRLEVBQUUsVUFBVTtZQUNwQixHQUFHLEVBQUUsTUFBSSxPQUFPLE9BQUk7WUFDcEIsSUFBSSxFQUFFLE1BQUksT0FBTyxPQUFJO1NBQ3RCLENBQUMsQ0FBQztRQUNMLElBQUksQ0FBQyxNQUFNLEdBQUcsU0FBUyxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUM7YUFDckMsSUFBSSxDQUFDLE9BQU8sRUFBRSxVQUFVLENBQUM7YUFDekIsSUFBSSxDQUFDLFFBQVEsRUFBRSxVQUFVLENBQUM7YUFDMUIsS0FBSyxDQUFDLE9BQU8sRUFBRSxDQUFDLEtBQUssR0FBRyxDQUFDLEdBQUcsT0FBTyxDQUFDLEdBQUcsSUFBSSxDQUFDO2FBQzVDLEtBQUssQ0FBQyxRQUFRLEVBQUUsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxHQUFHLE9BQU8sQ0FBQyxHQUFHLElBQUksQ0FBQzthQUM5QyxLQUFLLENBQUMsVUFBVSxFQUFFLFVBQVUsQ0FBQzthQUM3QixLQUFLLENBQUMsS0FBSyxFQUFLLE9BQU8sT0FBSSxDQUFDO2FBQzVCLEtBQUssQ0FBQyxNQUFNLEVBQUssT0FBTyxPQUFJLENBQUMsQ0FBQztRQUVqQyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztZQUN6QixJQUFJLENBQUMsR0FBRyxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDO2dCQUNwQyxPQUFPLEVBQUUsS0FBSztnQkFDZCxRQUFRLEVBQUUsTUFBTTthQUNuQixDQUFDLENBQUMsS0FBSyxDQUFDO2dCQUVQLFVBQVUsRUFBRSxVQUFVO2dCQUN0QixNQUFNLEVBQUUsR0FBRztnQkFDWCxLQUFLLEVBQUUsR0FBRzthQUNYLENBQUMsQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDO2lCQUNYLElBQUksQ0FBQyxXQUFXLEVBQUUsZUFBYSxPQUFPLFNBQUksT0FBTyxNQUFHLENBQUMsQ0FBQztZQUV6RCxJQUFJLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxDQUFDO1lBQzVDLElBQUksQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxPQUFPLEVBQUUsTUFBTSxDQUFDLENBQUM7UUFDN0MsQ0FBQztRQUVELEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztZQUMzQixJQUFJLEtBQUssR0FBRyxFQUFFLENBQUMsR0FBRyxDQUFDLElBQUksRUFBRTtpQkFDdEIsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUM7aUJBQ2xCLE1BQU0sQ0FBQyxRQUFRLENBQUMsQ0FBQztZQUVwQixJQUFJLEtBQUssR0FBRyxFQUFFLENBQUMsR0FBRyxDQUFDLElBQUksRUFBRTtpQkFDdEIsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUM7aUJBQ2xCLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQztZQUVuQixJQUFJLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUM7aUJBQ2pCLElBQUksQ0FBQyxPQUFPLEVBQUUsUUFBUSxDQUFDO2lCQUN2QixJQUFJLENBQUMsV0FBVyxFQUFFLGtCQUFlLE1BQU0sR0FBRyxDQUFDLEdBQUcsT0FBTyxPQUFHLENBQUM7aUJBQ3pELElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztZQUVmLElBQUksQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQztpQkFDakIsSUFBSSxDQUFDLE9BQU8sRUFBRSxRQUFRLENBQUM7aUJBQ3ZCLElBQUksQ0FBQyxXQUFXLEVBQUUsWUFBWSxHQUFHLENBQUMsS0FBSyxHQUFHLENBQUMsR0FBRyxPQUFPLENBQUMsR0FBRyxLQUFLLENBQUM7aUJBQy9ELElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNqQixDQUFDO0lBQ0gsQ0FBQztJQUVELGtDQUFnQixHQUFoQixVQUFpQixNQUFtQjtRQUNsQyxFQUFFLENBQUMsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7WUFDeEIsTUFBTSxLQUFLLENBQUMsbUNBQW1DLENBQUMsQ0FBQztRQUNuRCxDQUFDO1FBQ0QsSUFBSSxDQUFDLGFBQWEsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUN4RCxDQUFDO0lBRUQsOEJBQVksR0FBWixVQUFhLE1BQW1CO1FBQzlCLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQztZQUN4QixNQUFNLEtBQUssQ0FBQyxtQ0FBbUMsQ0FBQyxDQUFDO1FBQ25ELENBQUM7UUFDRCxJQUFJLENBQUMsYUFBYSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ3pELENBQUM7SUFFRCxrQ0FBZ0IsR0FBaEIsVUFBaUIsSUFBZ0IsRUFBRSxVQUFtQjtRQUNwRCxJQUFJLEVBQUUsR0FBRyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDO1FBQ3hCLElBQUksRUFBRSxHQUFHLElBQUksQ0FBQyxNQUFNLENBQUM7UUFFckIsRUFBRSxDQUFDLENBQUMsRUFBRSxLQUFLLElBQUksQ0FBQyxVQUFVLElBQUksRUFBRSxLQUFLLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1lBQ3JELE1BQU0sSUFBSSxLQUFLLENBQ1gsMkNBQTJDO2dCQUMzQyx5QkFBeUIsQ0FBQyxDQUFDO1FBQ2pDLENBQUM7UUFHRCxJQUFJLE9BQU8sR0FBdUIsSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFJLEVBQUcsQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDdkUsSUFBSSxLQUFLLEdBQUcsT0FBTyxDQUFDLGVBQWUsQ0FBQyxFQUFFLEVBQUUsRUFBRSxDQUFDLENBQUM7UUFFNUMsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxDQUFDLEdBQUcsRUFBRSxFQUFFLEVBQUUsQ0FBQyxFQUFFLENBQUM7WUFDcEMsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxFQUFFLEVBQUUsRUFBRSxDQUFDLEVBQUUsQ0FBQztnQkFDNUIsSUFBSSxLQUFLLEdBQUcsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUN2QixFQUFFLENBQUMsQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO29CQUNmLEtBQUssR0FBRyxDQUFDLEtBQUssSUFBSSxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7Z0JBQ2hDLENBQUM7Z0JBQ0QsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUM7Z0JBQ2xDLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUN0QixLQUFLLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDdEIsS0FBSyxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7Z0JBQ3RCLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLENBQUMsR0FBRyxHQUFHLENBQUM7WUFDeEIsQ0FBQztRQUNILENBQUM7UUFDRCxPQUFPLENBQUMsWUFBWSxDQUFDLEtBQUssRUFBRSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDcEMsQ0FBQztJQUVPLCtCQUFhLEdBQXJCLFVBQXNCLFNBQTRCLEVBQUUsTUFBbUI7UUFBdkUsaUJBeUJDO1FBdkJDLElBQUksT0FBTyxHQUFHLElBQUksQ0FBQyxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUM7UUFDbkMsSUFBSSxPQUFPLEdBQUcsSUFBSSxDQUFDLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNuQyxNQUFNLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxVQUFBLENBQUM7WUFDdEIsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLElBQUksT0FBTyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLElBQUksT0FBTyxDQUFDLENBQUMsQ0FBQzttQkFDeEMsQ0FBQyxDQUFDLENBQUMsSUFBSSxPQUFPLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsSUFBSSxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDOUMsQ0FBQyxDQUFDLENBQUM7UUFHSCxJQUFJLFNBQVMsR0FBRyxTQUFTLENBQUMsU0FBUyxDQUFDLFFBQVEsQ0FBQyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUczRCxTQUFTLENBQUMsS0FBSyxFQUFFLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFHaEQsU0FBUzthQUNOLElBQUksQ0FBQztZQUNKLEVBQUUsRUFBRSxVQUFDLENBQVksSUFBSyxPQUFBLEtBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFoQixDQUFnQjtZQUN0QyxFQUFFLEVBQUUsVUFBQyxDQUFZLElBQUssT0FBQSxLQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBaEIsQ0FBZ0I7U0FDdkMsQ0FBQzthQUNELEtBQUssQ0FBQyxNQUFNLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxLQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsRUFBbkIsQ0FBbUIsQ0FBQyxDQUFDO1FBRzNDLFNBQVMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxNQUFNLEVBQUUsQ0FBQztJQUM1QixDQUFDO0lBQ0gsY0FBQztBQUFELENBL0tBLEFBK0tDLElBQUE7QUEvS1ksZUFBTyxVQStLbkIsQ0FBQTtBQUVELHNCQUE2QixNQUFrQixFQUFFLE1BQWM7SUFDN0QsRUFBRSxDQUFDLENBQUMsTUFBTSxDQUFDLE1BQU0sS0FBSyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQztRQUN2QyxNQUFNLElBQUksS0FBSyxDQUFDLDZDQUE2QyxDQUFDLENBQUM7SUFDakUsQ0FBQztJQUNELEVBQUUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTSxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDakMsTUFBTSxJQUFJLEtBQUssQ0FBQyxzREFBc0Q7WUFDbEUsc0JBQXNCLENBQUMsQ0FBQztJQUM5QixDQUFDO0lBQ0QsSUFBSSxNQUFNLEdBQWUsSUFBSSxLQUFLLENBQUMsTUFBTSxDQUFDLE1BQU0sR0FBRyxNQUFNLENBQUMsQ0FBQztJQUMzRCxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQyxJQUFJLE1BQU0sRUFBRSxDQUFDO1FBQy9DLE1BQU0sQ0FBQyxDQUFDLEdBQUcsTUFBTSxDQUFDLEdBQUcsSUFBSSxLQUFLLENBQUMsTUFBTSxDQUFDLE1BQU0sR0FBRyxNQUFNLENBQUMsQ0FBQztRQUN2RCxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLE1BQU0sQ0FBQyxNQUFNLEVBQUUsQ0FBQyxJQUFJLE1BQU0sRUFBRSxDQUFDO1lBQy9DLElBQUksR0FBRyxHQUFHLENBQUMsQ0FBQztZQUVaLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7Z0JBQ2hDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7b0JBQ2hDLEdBQUcsSUFBSSxNQUFNLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztnQkFDOUIsQ0FBQztZQUNILENBQUM7WUFDRCxHQUFHLElBQUksQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLENBQUM7WUFDekIsTUFBTSxDQUFDLENBQUMsR0FBRyxNQUFNLENBQUMsQ0FBQyxDQUFDLEdBQUcsTUFBTSxDQUFDLEdBQUcsR0FBRyxDQUFDO1FBQ3ZDLENBQUM7SUFDSCxDQUFDO0lBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBeEJlLG9CQUFZLGVBd0IzQixDQUFBOzs7O0FDak5EO0lBWUUsNEJBQVksU0FBNEIsRUFBRSxVQUFvQjtRQVZ0RCxTQUFJLEdBQWdCLEVBQUUsQ0FBQztRQU92QixTQUFJLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQztRQUN4QixTQUFJLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQztRQUc5QixJQUFJLENBQUMsVUFBVSxHQUFHLFVBQVUsQ0FBQztRQUM3QixJQUFJLENBQUMsUUFBUSxHQUFHLFVBQVUsQ0FBQyxNQUFNLENBQUM7UUFDbEMsSUFBSSxJQUFJLEdBQWdCLFNBQVMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUN6QyxJQUFJLFVBQVUsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDO1FBQ2xDLElBQUksV0FBVyxHQUFHLElBQUksQ0FBQyxZQUFZLENBQUM7UUFDcEMsSUFBSSxNQUFNLEdBQUcsRUFBQyxHQUFHLEVBQUUsQ0FBQyxFQUFFLEtBQUssRUFBRSxDQUFDLEVBQUUsTUFBTSxFQUFFLENBQUMsRUFBRSxJQUFJLEVBQUUsQ0FBQyxFQUFDLENBQUM7UUFDcEQsSUFBSSxLQUFLLEdBQUcsVUFBVSxHQUFHLE1BQU0sQ0FBQyxJQUFJLEdBQUcsTUFBTSxDQUFDLEtBQUssQ0FBQztRQUNwRCxJQUFJLE1BQU0sR0FBRyxXQUFXLEdBQUcsTUFBTSxDQUFDLEdBQUcsR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDO1FBRXRELElBQUksQ0FBQyxNQUFNLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUU7YUFDNUIsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO2FBQ2QsS0FBSyxDQUFDLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxDQUFDLENBQUM7UUFFckIsSUFBSSxDQUFDLE1BQU0sR0FBRyxFQUFFLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRTthQUM1QixNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7YUFDZCxLQUFLLENBQUMsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUV0QixJQUFJLENBQUMsR0FBRyxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDO2FBQy9CLElBQUksQ0FBQyxPQUFPLEVBQUUsS0FBSyxHQUFHLE1BQU0sQ0FBQyxJQUFJLEdBQUcsTUFBTSxDQUFDLEtBQUssQ0FBQzthQUNqRCxJQUFJLENBQUMsUUFBUSxFQUFFLE1BQU0sR0FBRyxNQUFNLENBQUMsR0FBRyxHQUFHLE1BQU0sQ0FBQyxNQUFNLENBQUM7YUFDbkQsTUFBTSxDQUFDLEdBQUcsQ0FBQzthQUNULElBQUksQ0FBQyxXQUFXLEVBQUUsZUFBYSxNQUFNLENBQUMsSUFBSSxTQUFJLE1BQU0sQ0FBQyxHQUFHLE1BQUcsQ0FBQyxDQUFDO1FBRWxFLElBQUksQ0FBQyxLQUFLLEdBQUcsSUFBSSxLQUFLLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBQ3RDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsSUFBSSxDQUFDLFFBQVEsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQ3ZDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDO2lCQUNwQyxJQUFJLENBQUMsT0FBTyxFQUFFLE1BQU0sQ0FBQztpQkFDckIsS0FBSyxDQUFDO2dCQUNMLE1BQU0sRUFBRSxNQUFNO2dCQUNkLFFBQVEsRUFBRSxVQUFVLENBQUMsQ0FBQyxDQUFDO2dCQUN2QixjQUFjLEVBQUUsT0FBTzthQUN4QixDQUFDLENBQUM7UUFDUCxDQUFDO0lBQ0gsQ0FBQztJQUVELGtDQUFLLEdBQUw7UUFDRSxJQUFJLENBQUMsSUFBSSxHQUFHLEVBQUUsQ0FBQztRQUNmLElBQUksQ0FBQyxNQUFNLEVBQUUsQ0FBQztRQUNkLElBQUksQ0FBQyxJQUFJLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQztRQUM3QixJQUFJLENBQUMsSUFBSSxHQUFHLE1BQU0sQ0FBQyxTQUFTLENBQUM7SUFDL0IsQ0FBQztJQUVELHlDQUFZLEdBQVosVUFBYSxTQUFtQjtRQUFoQyxpQkFXQztRQVZDLEVBQUUsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxNQUFNLEtBQUssSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7WUFDdkMsTUFBTSxLQUFLLENBQUMsZ0RBQWdELENBQUMsQ0FBQztRQUNoRSxDQUFDO1FBQ0QsU0FBUyxDQUFDLE9BQU8sQ0FBQyxVQUFBLENBQUM7WUFDakIsS0FBSSxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLEtBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUM7WUFDbkMsS0FBSSxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsR0FBRyxDQUFDLEtBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDckMsQ0FBQyxDQUFDLENBQUM7UUFFSCxJQUFJLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxFQUFDLENBQUMsRUFBRSxJQUFJLENBQUMsSUFBSSxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQyxFQUFFLFNBQVMsRUFBQyxDQUFDLENBQUM7UUFDeEQsSUFBSSxDQUFDLE1BQU0sRUFBRSxDQUFDO0lBQ2hCLENBQUM7SUFFTyxtQ0FBTSxHQUFkO1FBQUEsaUJBYUM7UUFYQyxJQUFJLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRSxJQUFJLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDMUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxFQUFFLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO1FBRTNDLElBQUksVUFBVSxHQUFHLFVBQUMsU0FBaUI7WUFDakMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxHQUFHLENBQUMsSUFBSSxFQUFhO2lCQUM5QixDQUFDLENBQUMsVUFBQSxDQUFDLElBQUksT0FBQSxLQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBaEIsQ0FBZ0IsQ0FBQztpQkFDeEIsQ0FBQyxDQUFDLFVBQUEsQ0FBQyxJQUFJLE9BQUEsS0FBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxDQUFDLEVBQTNCLENBQTJCLENBQUMsQ0FBQztRQUN2QyxDQUFDLENBQUM7UUFDRixHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLElBQUksQ0FBQyxRQUFRLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUN2QyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUMxRCxDQUFDO0lBQ0gsQ0FBQztJQUNILHlCQUFDO0FBQUQsQ0FsRkEsQUFrRkMsSUFBQTtBQWxGWSwwQkFBa0IscUJBa0Y5QixDQUFBOzs7O0FDckZEO0lBOEJFLGNBQVksRUFBVSxFQUFFLFVBQThCO1FBM0J0RCxlQUFVLEdBQVcsRUFBRSxDQUFDO1FBQ3hCLFNBQUksR0FBRyxHQUFHLENBQUM7UUFFWCxZQUFPLEdBQVcsRUFBRSxDQUFDO1FBSXJCLGNBQVMsR0FBRyxDQUFDLENBQUM7UUFFZCxhQUFRLEdBQUcsQ0FBQyxDQUFDO1FBTWIsZ0JBQVcsR0FBRyxDQUFDLENBQUM7UUFLaEIsdUJBQWtCLEdBQUcsQ0FBQyxDQUFDO1FBUXJCLElBQUksQ0FBQyxFQUFFLEdBQUcsRUFBRSxDQUFDO1FBQ2IsSUFBSSxDQUFDLFVBQVUsR0FBRyxVQUFVLENBQUM7SUFDL0IsQ0FBQztJQUdELDJCQUFZLEdBQVo7UUFFRSxJQUFJLENBQUMsVUFBVSxHQUFHLElBQUksQ0FBQyxJQUFJLENBQUM7UUFDNUIsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQ2hELElBQUksSUFBSSxHQUFHLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDOUIsSUFBSSxDQUFDLFVBQVUsSUFBSSxJQUFJLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDO1FBQ3RELENBQUM7UUFDRCxJQUFJLENBQUMsTUFBTSxHQUFHLElBQUksQ0FBQyxVQUFVLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxVQUFVLENBQUMsQ0FBQztRQUN0RCxNQUFNLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQztJQUNyQixDQUFDO0lBQ0gsV0FBQztBQUFELENBOUNBLEFBOENDLElBQUE7QUE5Q1ksWUFBSSxPQThDaEIsQ0FBQTtBQXVCRDtJQUFBO0lBTUEsQ0FBQztJQUxlLGFBQU0sR0FBa0I7UUFDcEMsS0FBSyxFQUFFLFVBQUMsTUFBYyxFQUFFLE1BQWM7WUFDM0IsT0FBQSxHQUFHLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxNQUFNLEdBQUcsTUFBTSxFQUFFLENBQUMsQ0FBQztRQUFsQyxDQUFrQztRQUM3QyxHQUFHLEVBQUUsVUFBQyxNQUFjLEVBQUUsTUFBYyxJQUFLLE9BQUEsTUFBTSxHQUFHLE1BQU0sRUFBZixDQUFlO0tBQ3pELENBQUM7SUFDSixhQUFDO0FBQUQsQ0FOQSxBQU1DLElBQUE7QUFOWSxjQUFNLFNBTWxCLENBQUE7QUFHSyxJQUFLLENBQUMsSUFBSSxHQUFTLElBQUssQ0FBQyxJQUFJLElBQUksVUFBUyxDQUFDO0lBQy9DLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxRQUFRLENBQUMsQ0FBQyxDQUFDO1FBQ25CLE1BQU0sQ0FBQyxDQUFDLENBQUM7SUFDWCxDQUFDO0lBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDM0IsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ1osQ0FBQztJQUFDLElBQUksQ0FBQyxDQUFDO1FBQ04sSUFBSSxHQUFHLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUM7UUFDMUIsTUFBTSxDQUFDLENBQUMsR0FBRyxHQUFHLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxHQUFHLENBQUMsQ0FBQyxDQUFDO0lBQy9CLENBQUM7QUFDSCxDQUFDLENBQUM7QUFHRjtJQUFBO0lBNERBLENBQUM7SUEzRGUsa0JBQU0sR0FBdUI7UUFDekMsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQU0sSUFBSyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBbkIsQ0FBbUI7UUFDaEMsR0FBRyxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQUEsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBZixDQUFlO0tBQzFCLENBQUM7SUFDWSxnQkFBSSxHQUF1QjtRQUN2QyxNQUFNLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxDQUFPLElBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxFQUF6QyxDQUF5QztRQUN0RCxHQUFHLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQU8sSUFBSyxDQUFDLElBQUksQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxFQUF2QyxDQUF1QztLQUNsRCxDQUFDO0lBQ1ksZUFBRyxHQUF1QjtRQUN0QyxNQUFNLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxDQUFDLEdBQUcsQ0FBQyxHQUFTLElBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsRUFBbEMsQ0FBa0M7UUFDL0MsR0FBRyxFQUFFLFVBQUEsQ0FBQztZQUNKLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3ZDLE1BQU0sQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLE1BQU0sR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ2hDLENBQUM7S0FDRixDQUFDO0lBQ1ksb0JBQVEsR0FBdUI7UUFDM0MsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQU0sSUFBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBdkIsQ0FBdUI7UUFDcEMsR0FBRyxFQUFFLFVBQUEsQ0FBQztZQUNKLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQzVDLE1BQU0sQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsTUFBTSxDQUFDO1FBQ3pCLENBQUM7S0FDRixDQUFDO0lBQ1ksa0JBQU0sR0FBdUI7UUFDekMsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQUEsQ0FBQyxFQUFELENBQUM7UUFDZCxHQUFHLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxDQUFDLEVBQUQsQ0FBQztLQUNaLENBQUM7SUFDWSxnQkFBSSxHQUF1QjtRQUN2QyxNQUFNLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBTSxJQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsRUFBckIsQ0FBcUI7UUFDbEMsR0FBRyxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQUEsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxFQUFkLENBQWM7S0FDekIsQ0FBQztJQUNZLG1CQUFPLEdBQXVCO1FBQzFDLE1BQU0sRUFBRSxVQUFBLENBQUMsSUFBSSxPQUFBLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBUyxJQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBN0IsQ0FBNkI7UUFDMUMsR0FBRyxFQUFFLFVBQUEsQ0FBQztZQUNKLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQzNDLE1BQU0sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLEdBQUcsTUFBTSxDQUFDLENBQUM7UUFDL0IsQ0FBQztLQUNGLENBQUM7SUFDWSxvQkFBUSxHQUF1QjtRQUMzQyxNQUFNLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBTSxJQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFsQixDQUFrQjtRQUMvQixHQUFHLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBTSxJQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFsQixDQUFrQjtLQUM3QixDQUFDO0lBQ1ksb0JBQVEsR0FBdUI7UUFDM0MsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQU0sSUFBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQVMsSUFBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUF2QyxDQUF1QztRQUNwRCxHQUFHLEVBQUUsVUFBQSxDQUFDLElBQUksT0FBQSxXQUFXLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBN0IsQ0FBNkI7S0FDeEMsQ0FBQztJQUNZLG9CQUFRLEdBQXVCO1FBQzNDLE1BQU0sRUFBRSxVQUFBLENBQUMsSUFBSSxPQUFBLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBUyxJQUFLLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQTVCLENBQTRCO1FBQ3pDLEdBQUcsRUFBRSxVQUFBLENBQUM7WUFDSixJQUFJLElBQUksR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQVMsSUFBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3hDLE1BQU0sQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1FBQ3JCLENBQUM7S0FDRixDQUFDO0lBQ1ksZ0JBQUksR0FBdUI7UUFDdkMsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQU0sSUFBSyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsRUFBbkIsQ0FBbUI7UUFDaEMsR0FBRyxFQUFFLFVBQUEsQ0FBQztZQUNKLElBQUksTUFBTSxHQUFHLFdBQVcsQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3hDLE1BQU0sQ0FBQyxDQUFDLEdBQUcsTUFBTSxHQUFHLE1BQU0sQ0FBQztRQUM3QixDQUFDO0tBQ0YsQ0FBQztJQUNKLGtCQUFDO0FBQUQsQ0E1REEsQUE0REMsSUFBQTtBQTVEWSxtQkFBVyxjQTREdkIsQ0FBQTtBQUdEO0lBQUE7SUFTQSxDQUFDO0lBUmUseUJBQUUsR0FBMkI7UUFDekMsTUFBTSxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQUEsSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBWCxDQUFXO1FBQ3hCLEdBQUcsRUFBRSxVQUFBLENBQUMsSUFBSSxPQUFBLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxFQUFkLENBQWM7S0FDekIsQ0FBQztJQUNZLHlCQUFFLEdBQTJCO1FBQ3pDLE1BQU0sRUFBRSxVQUFBLENBQUMsSUFBSSxPQUFBLEdBQUcsR0FBRyxDQUFDLEdBQUcsQ0FBQyxFQUFYLENBQVc7UUFDeEIsR0FBRyxFQUFFLFVBQUEsQ0FBQyxJQUFJLE9BQUEsQ0FBQyxFQUFELENBQUM7S0FDWixDQUFDO0lBQ0osNkJBQUM7QUFBRCxDQVRBLEFBU0MsSUFBQTtBQVRZLDhCQUFzQix5QkFTbEMsQ0FBQTtBQVFEO0lBcUJFLGNBQVksTUFBWSxFQUFFLElBQVUsRUFDaEMsY0FBc0M7UUFsQjFDLFdBQU0sR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLEdBQUcsR0FBRyxDQUFDO1FBRTdCLGFBQVEsR0FBRyxDQUFDLENBQUM7UUFFYixnQkFBVyxHQUFHLENBQUMsQ0FBQztRQUVoQix1QkFBa0IsR0FBRyxDQUFDLENBQUM7UUFhckIsSUFBSSxDQUFDLEVBQUUsR0FBRyxNQUFNLENBQUMsRUFBRSxHQUFHLEdBQUcsR0FBRyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ3BDLElBQUksQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDO1FBQ3JCLElBQUksQ0FBQyxJQUFJLEdBQUcsSUFBSSxDQUFDO1FBQ2pCLElBQUksQ0FBQyxjQUFjLEdBQUcsY0FBYyxDQUFDO0lBQ3ZDLENBQUM7SUFDSCxXQUFDO0FBQUQsQ0E1QkEsQUE0QkMsSUFBQTtBQTVCWSxZQUFJLE9BNEJoQixDQUFBO0FBZUQsc0JBQ0ksWUFBc0IsRUFBRSxVQUE4QixFQUN0RCxnQkFBb0MsRUFDcEMsY0FBc0MsRUFDdEMsUUFBa0I7SUFDcEIsSUFBSSxTQUFTLEdBQUcsWUFBWSxDQUFDLE1BQU0sQ0FBQztJQUNwQyxJQUFJLEVBQUUsR0FBRyxDQUFDLENBQUM7SUFFWCxJQUFJLE9BQU8sR0FBYSxFQUFFLENBQUM7SUFDM0IsR0FBRyxDQUFDLENBQUMsSUFBSSxRQUFRLEdBQUcsQ0FBQyxFQUFFLFFBQVEsR0FBRyxTQUFTLEVBQUUsUUFBUSxFQUFFLEVBQUUsQ0FBQztRQUN4RCxJQUFJLGFBQWEsR0FBRyxRQUFRLEtBQUssU0FBUyxHQUFHLENBQUMsQ0FBQztRQUMvQyxJQUFJLFlBQVksR0FBRyxRQUFRLEtBQUssQ0FBQyxDQUFDO1FBQ2xDLElBQUksWUFBWSxHQUFXLEVBQUUsQ0FBQztRQUM5QixPQUFPLENBQUMsSUFBSSxDQUFDLFlBQVksQ0FBQyxDQUFDO1FBQzNCLElBQUksUUFBUSxHQUFHLFlBQVksQ0FBQyxRQUFRLENBQUMsQ0FBQztRQUN0QyxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLFFBQVEsRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQ2xDLElBQUksTUFBTSxHQUFHLEVBQUUsQ0FBQyxRQUFRLEVBQUUsQ0FBQztZQUMzQixFQUFFLENBQUMsQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO2dCQUNqQixNQUFNLEdBQUcsUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3ZCLENBQUM7WUFBQyxJQUFJLENBQUMsQ0FBQztnQkFDTixFQUFFLEVBQUUsQ0FBQztZQUNQLENBQUM7WUFDRCxJQUFJLElBQUksR0FBRyxJQUFJLElBQUksQ0FBQyxNQUFNLEVBQ3RCLGFBQWEsR0FBRyxnQkFBZ0IsR0FBRyxVQUFVLENBQUMsQ0FBQztZQUNuRCxZQUFZLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO1lBQ3hCLEVBQUUsQ0FBQyxDQUFDLFFBQVEsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUVsQixHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLE9BQU8sQ0FBQyxRQUFRLEdBQUcsQ0FBQyxDQUFDLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7b0JBQ3RELElBQUksUUFBUSxHQUFHLE9BQU8sQ0FBQyxRQUFRLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7b0JBQ3hDLElBQUksSUFBSSxHQUFHLElBQUksSUFBSSxDQUFDLFFBQVEsRUFBRSxJQUFJLEVBQUUsY0FBYyxDQUFDLENBQUM7b0JBQ3BELFFBQVEsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO29CQUM1QixJQUFJLENBQUMsVUFBVSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztnQkFDN0IsQ0FBQztZQUNILENBQUM7UUFDSCxDQUFDO0lBQ0gsQ0FBQztJQUNELE1BQU0sQ0FBQyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQXJDZSxvQkFBWSxlQXFDM0IsQ0FBQTtBQVlELHFCQUE0QixPQUFpQixFQUFFLE1BQWdCO0lBQzdELElBQUksVUFBVSxHQUFHLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUM1QixFQUFFLENBQUMsQ0FBQyxNQUFNLENBQUMsTUFBTSxLQUFLLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO1FBQ3hDLE1BQU0sSUFBSSxLQUFLLENBQUMsd0RBQXdEO1lBQ3BFLGtCQUFrQixDQUFDLENBQUM7SUFDMUIsQ0FBQztJQUVELEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1FBQzNDLElBQUksSUFBSSxHQUFHLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUN6QixJQUFJLENBQUMsTUFBTSxHQUFHLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUMxQixDQUFDO0lBQ0QsR0FBRyxDQUFDLENBQUMsSUFBSSxRQUFRLEdBQUcsQ0FBQyxFQUFFLFFBQVEsR0FBRyxPQUFPLENBQUMsTUFBTSxFQUFFLFFBQVEsRUFBRSxFQUFFLENBQUM7UUFDN0QsSUFBSSxZQUFZLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBRXJDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsWUFBWSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQzdDLElBQUksSUFBSSxHQUFHLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUMzQixJQUFJLENBQUMsWUFBWSxFQUFFLENBQUM7UUFDdEIsQ0FBQztJQUNILENBQUM7SUFDRCxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDO0FBQy9DLENBQUM7QUFwQmUsbUJBQVcsY0FvQjFCLENBQUE7QUFTRCxrQkFBeUIsT0FBaUIsRUFBRSxNQUFjLEVBQ3RELFNBQXdCO0lBRzFCLElBQUksVUFBVSxHQUFHLE9BQU8sQ0FBQyxPQUFPLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ2hELFVBQVUsQ0FBQyxTQUFTLEdBQUcsU0FBUyxDQUFDLEdBQUcsQ0FBQyxVQUFVLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBR2hFLEdBQUcsQ0FBQyxDQUFDLElBQUksUUFBUSxHQUFHLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLFFBQVEsSUFBSSxDQUFDLEVBQUUsUUFBUSxFQUFFLEVBQUUsQ0FBQztRQUNsRSxJQUFJLFlBQVksR0FBRyxPQUFPLENBQUMsUUFBUSxDQUFDLENBQUM7UUFJckMsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxZQUFZLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDN0MsSUFBSSxJQUFJLEdBQUcsWUFBWSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQzNCLElBQUksQ0FBQyxRQUFRLEdBQUcsSUFBSSxDQUFDLFNBQVMsR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUM7WUFDdEUsSUFBSSxDQUFDLFdBQVcsSUFBSSxJQUFJLENBQUMsUUFBUSxDQUFDO1lBQ2xDLElBQUksQ0FBQyxrQkFBa0IsRUFBRSxDQUFDO1FBQzVCLENBQUM7UUFHRCxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLFlBQVksQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUM3QyxJQUFJLElBQUksR0FBRyxZQUFZLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDM0IsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO2dCQUNoRCxJQUFJLElBQUksR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUM5QixJQUFJLENBQUMsUUFBUSxHQUFHLElBQUksQ0FBQyxRQUFRLEdBQUcsSUFBSSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUM7Z0JBQ25ELElBQUksQ0FBQyxXQUFXLElBQUksSUFBSSxDQUFDLFFBQVEsQ0FBQztnQkFDbEMsSUFBSSxDQUFDLGtCQUFrQixFQUFFLENBQUM7WUFDNUIsQ0FBQztRQUNILENBQUM7UUFDRCxFQUFFLENBQUMsQ0FBQyxRQUFRLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNuQixRQUFRLENBQUM7UUFDWCxDQUFDO1FBQ0QsSUFBSSxTQUFTLEdBQUcsT0FBTyxDQUFDLFFBQVEsR0FBRyxDQUFDLENBQUMsQ0FBQztRQUN0QyxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLFNBQVMsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUMxQyxJQUFJLElBQUksR0FBRyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFFeEIsSUFBSSxDQUFDLFNBQVMsR0FBRyxDQUFDLENBQUM7WUFDbkIsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLENBQUMsT0FBTyxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO2dCQUM3QyxJQUFJLE1BQU0sR0FBRyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUM3QixJQUFJLENBQUMsU0FBUyxJQUFJLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUM7WUFDekQsQ0FBQztRQUNILENBQUM7SUFDSCxDQUFDO0FBQ0gsQ0FBQztBQTVDZSxnQkFBUSxXQTRDdkIsQ0FBQTtBQU1ELHVCQUE4QixPQUFpQixFQUFFLFlBQW9CLEVBQ2pFLGtCQUEwQjtJQUM1QixHQUFHLENBQUMsQ0FBQyxJQUFJLFFBQVEsR0FBRyxDQUFDLEVBQUUsUUFBUSxHQUFHLE9BQU8sQ0FBQyxNQUFNLEVBQUUsUUFBUSxFQUFFLEVBQUUsQ0FBQztRQUM3RCxJQUFJLFlBQVksR0FBRyxPQUFPLENBQUMsUUFBUSxDQUFDLENBQUM7UUFDckMsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxZQUFZLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDN0MsSUFBSSxJQUFJLEdBQUcsWUFBWSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBRTNCLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUNoQyxJQUFJLENBQUMsSUFBSSxJQUFJLFlBQVksR0FBRyxJQUFJLENBQUMsV0FBVyxHQUFHLElBQUksQ0FBQyxrQkFBa0IsQ0FBQztnQkFDdkUsSUFBSSxDQUFDLFdBQVcsR0FBRyxDQUFDLENBQUM7Z0JBQ3JCLElBQUksQ0FBQyxrQkFBa0IsR0FBRyxDQUFDLENBQUM7WUFDOUIsQ0FBQztZQUVELEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsSUFBSSxDQUFDLFVBQVUsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztnQkFDaEQsSUFBSSxJQUFJLEdBQUcsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDOUIsSUFBSSxRQUFRLEdBQUcsSUFBSSxDQUFDLGNBQWM7b0JBQzlCLElBQUksQ0FBQyxjQUFjLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUM7Z0JBQzdDLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxrQkFBa0IsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO29CQUNoQyxJQUFJLENBQUMsTUFBTSxJQUFJLENBQUMsWUFBWSxHQUFHLElBQUksQ0FBQyxrQkFBa0IsQ0FBQzt3QkFDckQsQ0FBQyxJQUFJLENBQUMsV0FBVyxHQUFHLGtCQUFrQixHQUFHLFFBQVEsQ0FBQyxDQUFDO29CQUNyRCxJQUFJLENBQUMsV0FBVyxHQUFHLENBQUMsQ0FBQztvQkFDckIsSUFBSSxDQUFDLGtCQUFrQixHQUFHLENBQUMsQ0FBQztnQkFDOUIsQ0FBQztZQUNILENBQUM7UUFDSCxDQUFDO0lBQ0gsQ0FBQztBQUNILENBQUM7QUExQmUscUJBQWEsZ0JBMEI1QixDQUFBO0FBR0QscUJBQTRCLE9BQWlCLEVBQUUsWUFBcUIsRUFDaEUsUUFBNkI7SUFDL0IsR0FBRyxDQUFDLENBQUMsSUFBSSxRQUFRLEdBQUcsWUFBWSxHQUFHLENBQUMsR0FBRyxDQUFDLEVBQ3BDLFFBQVEsR0FBRyxPQUFPLENBQUMsTUFBTSxFQUN6QixRQUFRLEVBQUUsRUFBRSxDQUFDO1FBQ2YsSUFBSSxZQUFZLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBQ3JDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsWUFBWSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQzdDLElBQUksSUFBSSxHQUFHLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUMzQixRQUFRLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDakIsQ0FBQztJQUNILENBQUM7QUFDSCxDQUFDO0FBWGUsbUJBQVcsY0FXMUIsQ0FBQTtBQUdELHVCQUE4QixPQUFpQjtJQUM3QyxNQUFNLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7QUFDeEMsQ0FBQztBQUZlLHFCQUFhLGdCQUU1QixDQUFBOzs7O0FDcFlELElBQVksRUFBRSxXQUFNLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLHdCQUFvQyxXQUFXLENBQUMsQ0FBQTtBQUNoRCxzQkFTTyxTQUFTLENBQUMsQ0FBQTtBQUNqQix3QkFBaUMsV0FBVyxDQUFDLENBQUE7QUFDN0MsMEJBQWlDLGFBQWEsQ0FBQyxDQUFBO0FBRS9DLElBQUksU0FBUyxDQUFDO0FBR2QsRUFBRSxDQUFDLE1BQU0sQ0FBQyxjQUFjLENBQUMsQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFO0lBQ3BDLElBQUksUUFBUSxHQUFHLEdBQUcsQ0FBQztJQUNuQixFQUFFLENBQUMsVUFBVSxFQUFFO1NBQ1osUUFBUSxDQUFDLElBQUksQ0FBQztTQUNkLEtBQUssQ0FBQyxRQUFRLEVBQUUsV0FBVyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7QUFDNUMsQ0FBQyxDQUFDLENBQUM7QUFFSCxxQkFBcUIsTUFBTTtJQUN6QixNQUFNLENBQUM7UUFDTCxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsaUJBQWlCLENBQUMsTUFBTSxDQUFDLFdBQVc7WUFDM0MsUUFBUSxDQUFDLGVBQWUsQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7UUFDaEQsTUFBTSxDQUFDLFVBQVMsQ0FBQyxJQUFJLFFBQVEsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDNUMsQ0FBQyxDQUFDO0FBQ0osQ0FBQztBQUVELElBQU0sU0FBUyxHQUFHLEVBQUUsQ0FBQztBQUNyQixJQUFNLFNBQVMsR0FBRyxDQUFDLENBQUM7QUFDcEIsSUFBTSxvQkFBb0IsR0FBRyxHQUFHLENBQUM7QUFDakMsSUFBTSxtQkFBbUIsR0FBRyxJQUFJLENBQUM7QUFDakMsSUFBTSxPQUFPLEdBQUcsR0FBRyxDQUFDO0FBRXBCLElBQUssU0FFSjtBQUZELFdBQUssU0FBUztJQUNaLHlDQUFJLENBQUE7SUFBRSw2Q0FBTSxDQUFBO0FBQ2QsQ0FBQyxFQUZJLFNBQVMsS0FBVCxTQUFTLFFBRWI7QUFPRCxJQUFJLE1BQU0sR0FBbUM7SUFDM0MsR0FBRyxFQUFFLEVBQUMsQ0FBQyxFQUFFLFVBQUMsQ0FBQyxFQUFFLENBQUMsSUFBSyxPQUFBLENBQUMsRUFBRCxDQUFDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBQztJQUNuQyxHQUFHLEVBQUUsRUFBQyxDQUFDLEVBQUUsVUFBQyxDQUFDLEVBQUUsQ0FBQyxJQUFLLE9BQUEsQ0FBQyxFQUFELENBQUMsRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFDO0lBQ25DLFVBQVUsRUFBRSxFQUFDLENBQUMsRUFBRSxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxDQUFDLEdBQUcsQ0FBQyxFQUFMLENBQUssRUFBRSxLQUFLLEVBQUUsT0FBTyxFQUFDO0lBQ2hELFVBQVUsRUFBRSxFQUFDLENBQUMsRUFBRSxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxDQUFDLEdBQUcsQ0FBQyxFQUFMLENBQUssRUFBRyxLQUFLLEVBQUUsT0FBTyxFQUFDO0lBQ2pELFNBQVMsRUFBRSxFQUFDLENBQUMsRUFBRSxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxDQUFDLEdBQUcsQ0FBQyxFQUFMLENBQUssRUFBRSxLQUFLLEVBQUUsUUFBUSxFQUFDO0lBQ2hELE1BQU0sRUFBRSxFQUFDLENBQUMsRUFBRSxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFYLENBQVcsRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFDO0lBQ3JELE1BQU0sRUFBRSxFQUFDLENBQUMsRUFBRSxVQUFDLENBQUMsRUFBRSxDQUFDLElBQUssT0FBQSxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxFQUFYLENBQVcsRUFBRSxLQUFLLEVBQUUsVUFBVSxFQUFDO0NBQ3RELENBQUM7QUFFRixJQUFJLGdCQUFnQixHQUFHO0lBQ3JCLENBQUMsZ0JBQWdCLEVBQUUsY0FBYyxDQUFDO0lBQ2xDLENBQUMsbUJBQW1CLEVBQUUsWUFBWSxDQUFDO0lBQ25DLENBQUMsYUFBYSxFQUFFLFlBQVksQ0FBQztJQUM3QixDQUFDLGFBQWEsRUFBRSxZQUFZLENBQUM7SUFDN0IsQ0FBQyxjQUFjLEVBQUUsYUFBYSxDQUFDO0lBQy9CLENBQUMsZUFBZSxFQUFFLGNBQWMsQ0FBQztJQUNqQyxDQUFDLFlBQVksRUFBRSxZQUFZLENBQUM7SUFDNUIsQ0FBQyxnQkFBZ0IsRUFBRSxnQkFBZ0IsQ0FBQztJQUNwQyxDQUFDLHFCQUFxQixFQUFFLG9CQUFvQixDQUFDO0lBQzdDLENBQUMsY0FBYyxFQUFFLFNBQVMsQ0FBQztJQUMzQixDQUFDLGVBQWUsRUFBRSxTQUFTLENBQUM7SUFDNUIsQ0FBQyxrQkFBa0IsRUFBRSxlQUFlLENBQUM7SUFDckMsQ0FBQyxhQUFhLEVBQUUsT0FBTyxDQUFDO0lBQ3hCLENBQUMsWUFBWSxFQUFFLFdBQVcsQ0FBQztJQUMzQixDQUFDLG9CQUFvQixFQUFFLGlCQUFpQixDQUFDO0NBQzFDLENBQUM7QUFFRjtJQUFBO1FBQ1UsZUFBVSxHQUFHLENBQUMsQ0FBQztRQUNmLGNBQVMsR0FBRyxLQUFLLENBQUM7UUFDbEIsYUFBUSxHQUFpQyxJQUFJLENBQUM7SUEyQ3hELENBQUM7SUF4Q0MsNEJBQVcsR0FBWDtRQUNFLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDO1lBQ25CLElBQUksQ0FBQyxTQUFTLEdBQUcsS0FBSyxDQUFDO1lBQ3ZCLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNmLENBQUM7UUFBQyxJQUFJLENBQUMsQ0FBQztZQUNOLElBQUksQ0FBQyxTQUFTLEdBQUcsSUFBSSxDQUFDO1lBQ3RCLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQztRQUNkLENBQUM7SUFDSCxDQUFDO0lBRUQsNEJBQVcsR0FBWCxVQUFZLFFBQXNDO1FBQ2hELElBQUksQ0FBQyxRQUFRLEdBQUcsUUFBUSxDQUFDO0lBQzNCLENBQUM7SUFFRCxxQkFBSSxHQUFKO1FBQ0UsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ2IsSUFBSSxDQUFDLFNBQVMsR0FBRyxJQUFJLENBQUM7UUFDdEIsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7WUFDbEIsSUFBSSxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLENBQUM7UUFDaEMsQ0FBQztRQUNELElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzlCLENBQUM7SUFFRCxzQkFBSyxHQUFMO1FBQ0UsSUFBSSxDQUFDLFVBQVUsRUFBRSxDQUFDO1FBQ2xCLElBQUksQ0FBQyxTQUFTLEdBQUcsS0FBSyxDQUFDO1FBQ3ZCLEVBQUUsQ0FBQyxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDO1lBQ2xCLElBQUksQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1FBQ2hDLENBQUM7SUFDSCxDQUFDO0lBRU8sc0JBQUssR0FBYixVQUFjLGVBQXVCO1FBQXJDLGlCQVFDO1FBUEMsRUFBRSxDQUFDLEtBQUssQ0FBQztZQUNQLEVBQUUsQ0FBQyxDQUFDLGVBQWUsR0FBRyxLQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztnQkFDdEMsTUFBTSxDQUFDLElBQUksQ0FBQztZQUNkLENBQUM7WUFDRCxPQUFPLEVBQUUsQ0FBQztZQUNWLE1BQU0sQ0FBQyxLQUFLLENBQUM7UUFDZixDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDUixDQUFDO0lBQ0gsYUFBQztBQUFELENBOUNBLEFBOENDLElBQUE7QUFFRCxJQUFJLEtBQUssR0FBRyxhQUFLLENBQUMsZ0JBQWdCLEVBQUUsQ0FBQztBQUdyQyxLQUFLLENBQUMsY0FBYyxFQUFFLENBQUMsT0FBTyxDQUFDLFVBQUEsSUFBSTtJQUNqQyxFQUFFLENBQUMsQ0FBQyxJQUFJLElBQUksTUFBTSxDQUFDLENBQUMsQ0FBQztRQUNuQixPQUFPLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN0QixDQUFDO0FBQ0gsQ0FBQyxDQUFDLENBQUM7QUFFSCxJQUFJLFFBQVEsR0FBK0IsRUFBRSxDQUFDO0FBQzlDLElBQUksY0FBYyxHQUFXLElBQUksQ0FBQztBQUVsQyxJQUFJLE9BQU8sR0FBcUIsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztBQUN4QyxJQUFJLE9BQU8sR0FDUCxJQUFJLGlCQUFPLENBQUMsR0FBRyxFQUFFLE9BQU8sRUFBRSxPQUFPLEVBQUUsT0FBTyxFQUFFLEVBQUUsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDLEVBQzdELEVBQUMsUUFBUSxFQUFFLElBQUksRUFBQyxDQUFDLENBQUM7QUFDMUIsSUFBSSxjQUFjLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUU7S0FDbkMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO0tBQ2QsS0FBSyxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDO0tBQ2QsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ2YsSUFBSSxVQUFVLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQVU7S0FDcEIsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO0tBQ2xCLEtBQUssQ0FBQyxDQUFDLFNBQVMsRUFBRSxTQUFTLEVBQUUsU0FBUyxDQUFDLENBQUM7S0FDeEMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ2xDLElBQUksSUFBSSxHQUFHLENBQUMsQ0FBQztBQUNiLElBQUksU0FBUyxHQUFnQixFQUFFLENBQUM7QUFDaEMsSUFBSSxRQUFRLEdBQWdCLEVBQUUsQ0FBQztBQUMvQixJQUFJLE9BQU8sR0FBZ0IsSUFBSSxDQUFDO0FBQ2hDLElBQUksU0FBUyxHQUFHLENBQUMsQ0FBQztBQUNsQixJQUFJLFFBQVEsR0FBRyxDQUFDLENBQUM7QUFDakIsSUFBSSxNQUFNLEdBQUcsSUFBSSxNQUFNLEVBQUUsQ0FBQztBQUMxQixJQUFJLFNBQVMsR0FBRyxJQUFJLDhCQUFrQixDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLEVBQzFELENBQUMsTUFBTSxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUM7QUFFdkI7SUFDRSxFQUFFLENBQUMsTUFBTSxDQUFDLGVBQWUsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxPQUFPLEVBQUU7UUFDckMsS0FBSyxFQUFFLENBQUM7UUFDUixFQUFFLENBQUMsTUFBTSxDQUFDLG9CQUFvQixDQUFDLENBQUM7SUFDbEMsQ0FBQyxDQUFDLENBQUM7SUFFSCxFQUFFLENBQUMsTUFBTSxDQUFDLG9CQUFvQixDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUUxQyxNQUFNLENBQUMsV0FBVyxFQUFFLENBQUM7SUFDdkIsQ0FBQyxDQUFDLENBQUM7SUFFSCxNQUFNLENBQUMsV0FBVyxDQUFDLFVBQUEsU0FBUztRQUMxQixFQUFFLENBQUMsTUFBTSxDQUFDLG9CQUFvQixDQUFDLENBQUMsT0FBTyxDQUFDLFNBQVMsRUFBRSxTQUFTLENBQUMsQ0FBQztJQUNoRSxDQUFDLENBQUMsQ0FBQztJQUVILEVBQUUsQ0FBQyxNQUFNLENBQUMsbUJBQW1CLENBQUMsQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFO1FBQ3pDLE1BQU0sQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNmLE9BQU8sRUFBRSxDQUFDO0lBQ1osQ0FBQyxDQUFDLENBQUM7SUFFSCxFQUFFLENBQUMsTUFBTSxDQUFDLG9CQUFvQixDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUMxQyxZQUFZLEVBQUUsQ0FBQztJQUNqQixDQUFDLENBQUMsQ0FBQztJQUVILElBQUksY0FBYyxHQUFHLEVBQUUsQ0FBQyxTQUFTLENBQUMsc0JBQXNCLENBQUMsQ0FBQztJQUMxRCxjQUFjLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUN6QixJQUFJLFVBQVUsR0FBRyxnQkFBUSxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDaEQsRUFBRSxDQUFDLENBQUMsVUFBVSxLQUFLLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1lBQ2pDLE1BQU0sQ0FBQztRQUNULENBQUM7UUFDRCxLQUFLLENBQUMsT0FBTyxHQUFJLFVBQVUsQ0FBQztRQUM1QixjQUFjLENBQUMsT0FBTyxDQUFDLFVBQVUsRUFBRSxLQUFLLENBQUMsQ0FBQztRQUMxQyxFQUFFLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLE9BQU8sQ0FBQyxVQUFVLEVBQUUsSUFBSSxDQUFDLENBQUM7UUFDMUMsWUFBWSxFQUFFLENBQUM7UUFDZixLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBRUgsSUFBSSxVQUFVLEdBQUcsdUJBQWUsQ0FBQyxnQkFBUSxFQUFFLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUUxRCxFQUFFLENBQUMsTUFBTSxDQUFDLHlCQUF1QixVQUFVLE1BQUcsQ0FBQztTQUM1QyxPQUFPLENBQUMsVUFBVSxFQUFFLElBQUksQ0FBQyxDQUFDO0lBRTdCLElBQUksaUJBQWlCLEdBQUcsRUFBRSxDQUFDLFNBQVMsQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO0lBQ2hFLGlCQUFpQixDQUFDLEVBQUUsQ0FBQyxPQUFPLEVBQUU7UUFDNUIsSUFBSSxVQUFVLEdBQUcsbUJBQVcsQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1FBQ3RELEVBQUUsQ0FBQyxDQUFDLFVBQVUsS0FBSyxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQztZQUNwQyxNQUFNLENBQUM7UUFDVCxDQUFDO1FBQ0QsS0FBSyxDQUFDLFVBQVUsR0FBSSxVQUFVLENBQUM7UUFDL0IsaUJBQWlCLENBQUMsT0FBTyxDQUFDLFVBQVUsRUFBRSxLQUFLLENBQUMsQ0FBQztRQUM3QyxFQUFFLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDLE9BQU8sQ0FBQyxVQUFVLEVBQUUsSUFBSSxDQUFDLENBQUM7UUFDMUMsWUFBWSxFQUFFLENBQUM7UUFDZixLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBRUgsSUFBSSxhQUFhLEdBQUcsdUJBQWUsQ0FBQyxtQkFBVyxFQUFFLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUVuRSxFQUFFLENBQUMsTUFBTSxDQUFDLDRCQUEwQixhQUFhLE1BQUcsQ0FBQztTQUNsRCxPQUFPLENBQUMsVUFBVSxFQUFFLElBQUksQ0FBQyxDQUFDO0lBRTdCLEVBQUUsQ0FBQyxNQUFNLENBQUMsYUFBYSxDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUNuQyxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsZUFBZSxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDL0IsTUFBTSxDQUFDO1FBQ1QsQ0FBQztRQUNELEtBQUssQ0FBQyxZQUFZLENBQUMsS0FBSyxDQUFDLGVBQWUsQ0FBQyxHQUFHLENBQUMsQ0FBQztRQUM5QyxLQUFLLENBQUMsZUFBZSxFQUFFLENBQUM7UUFDeEIsS0FBSyxFQUFFLENBQUM7SUFDVixDQUFDLENBQUMsQ0FBQztJQUVILEVBQUUsQ0FBQyxNQUFNLENBQUMsZ0JBQWdCLENBQUMsQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFO1FBQ3RDLEVBQUUsQ0FBQyxDQUFDLEtBQUssQ0FBQyxlQUFlLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUMvQixNQUFNLENBQUM7UUFDVCxDQUFDO1FBQ0QsS0FBSyxDQUFDLGVBQWUsRUFBRSxDQUFDO1FBQ3hCLEtBQUssQ0FBQyxZQUFZLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxlQUFlLENBQUMsQ0FBQztRQUNqRCxLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBRUgsSUFBSSxZQUFZLEdBQUcsRUFBRSxDQUFDLE1BQU0sQ0FBQyxpQkFBaUIsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxRQUFRLEVBQUU7UUFDM0QsS0FBSyxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsT0FBTyxDQUFDO1FBQ2xDLEtBQUssQ0FBQyxTQUFTLEVBQUUsQ0FBQztRQUNsQixPQUFPLENBQUMsZ0JBQWdCLENBQUMsS0FBSyxDQUFDLFlBQVksR0FBRyxRQUFRLEdBQUcsRUFBRSxDQUFDLENBQUM7SUFDL0QsQ0FBQyxDQUFDLENBQUM7SUFFSCxZQUFZLENBQUMsUUFBUSxDQUFDLFNBQVMsRUFBRSxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUM7SUFFckQsSUFBSSxVQUFVLEdBQUcsRUFBRSxDQUFDLE1BQU0sQ0FBQyxhQUFhLENBQUMsQ0FBQyxFQUFFLENBQUMsUUFBUSxFQUFFO1FBQ3JELEtBQUssQ0FBQyxVQUFVLEdBQUcsSUFBSSxDQUFDLE9BQU8sQ0FBQztRQUNoQyxLQUFLLENBQUMsU0FBUyxFQUFFLENBQUM7UUFDbEIsUUFBUSxFQUFFLENBQUM7SUFDYixDQUFDLENBQUMsQ0FBQztJQUVILFVBQVUsQ0FBQyxRQUFRLENBQUMsU0FBUyxFQUFFLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUVqRCxJQUFJLFNBQVMsR0FBRyxFQUFFLENBQUMsTUFBTSxDQUFDLGdCQUFnQixDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUN0RCxLQUFLLENBQUMsYUFBYSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUM7UUFDakMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxtQ0FBbUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDaEUsWUFBWSxFQUFFLENBQUM7UUFDZixLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBQ0gsU0FBUyxDQUFDLFFBQVEsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLGFBQWEsQ0FBQyxDQUFDO0lBQ2pELEVBQUUsQ0FBQyxNQUFNLENBQUMsbUNBQW1DLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLGFBQWEsQ0FBQyxDQUFDO0lBRXpFLElBQUksS0FBSyxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUMxQyxLQUFLLENBQUMsS0FBSyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUM7UUFDekIsRUFBRSxDQUFDLE1BQU0sQ0FBQywyQkFBMkIsQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDeEQsWUFBWSxFQUFFLENBQUM7UUFDZixLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBQ0gsS0FBSyxDQUFDLFFBQVEsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBQ3JDLEVBQUUsQ0FBQyxNQUFNLENBQUMsMkJBQTJCLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDO0lBRXpELElBQUksU0FBUyxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtRQUNsRCxLQUFLLENBQUMsU0FBUyxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUM7UUFDN0IsRUFBRSxDQUFDLE1BQU0sQ0FBQywrQkFBK0IsQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDNUQsS0FBSyxFQUFFLENBQUM7SUFDVixDQUFDLENBQUMsQ0FBQztJQUNILFNBQVMsQ0FBQyxRQUFRLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUM3QyxFQUFFLENBQUMsTUFBTSxDQUFDLCtCQUErQixDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUVqRSxJQUFJLGtCQUFrQixHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsY0FBYyxDQUFDLENBQUMsRUFBRSxDQUFDLFFBQVEsRUFBRTtRQUM5RCxLQUFLLENBQUMsVUFBVSxHQUFHLG1CQUFXLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzNDLGdCQUFnQixFQUFFLENBQUM7SUFDckIsQ0FBQyxDQUFDLENBQUM7SUFDSCxrQkFBa0IsQ0FBQyxRQUFRLENBQUMsT0FBTyxFQUMvQix1QkFBZSxDQUFDLG1CQUFXLEVBQUUsS0FBSyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7SUFFcEQsSUFBSSxZQUFZLEdBQUcsRUFBRSxDQUFDLE1BQU0sQ0FBQyxlQUFlLENBQUMsQ0FBQyxFQUFFLENBQUMsUUFBUSxFQUFFO1FBQ3pELEtBQUssQ0FBQyxZQUFZLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDO0lBQ25DLENBQUMsQ0FBQyxDQUFDO0lBQ0gsWUFBWSxDQUFDLFFBQVEsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDO0lBRW5ELElBQUksZUFBZSxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsa0JBQWtCLENBQUMsQ0FBQyxFQUFFLENBQUMsUUFBUSxFQUMzRDtRQUNGLEtBQUssQ0FBQyxjQUFjLEdBQUcsdUJBQWUsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDbkQsS0FBSyxFQUFFLENBQUM7SUFDVixDQUFDLENBQUMsQ0FBQztJQUNILGVBQWUsQ0FBQyxRQUFRLENBQUMsT0FBTyxFQUM1Qix1QkFBZSxDQUFDLHVCQUFlLEVBQUUsS0FBSyxDQUFDLGNBQWMsQ0FBQyxDQUFDLENBQUM7SUFFNUQsSUFBSSxXQUFXLEdBQUcsRUFBRSxDQUFDLE1BQU0sQ0FBQyxjQUFjLENBQUMsQ0FBQyxFQUFFLENBQUMsUUFBUSxFQUFFO1FBQ3ZELEtBQUssQ0FBQyxrQkFBa0IsR0FBRyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUM7UUFDdkMsS0FBSyxFQUFFLENBQUM7SUFDVixDQUFDLENBQUMsQ0FBQztJQUNILFdBQVcsQ0FBQyxRQUFRLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO0lBRXhELElBQUksT0FBTyxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUMsRUFBRSxDQUFDLFFBQVEsRUFBRTtRQUMvQyxLQUFLLENBQUMsT0FBTyxHQUFHLGdCQUFRLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQ3JDLFlBQVksRUFBRSxDQUFDO1FBQ2YscUJBQXFCLEVBQUUsQ0FBQztRQUN4QixLQUFLLEVBQUUsQ0FBQztJQUNWLENBQUMsQ0FBQyxDQUFDO0lBQ0gsT0FBTyxDQUFDLFFBQVEsQ0FBQyxPQUFPLEVBQUUsdUJBQWUsQ0FBQyxnQkFBUSxFQUFFLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBR3BFLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLEVBQUUsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUMxRCxJQUFJLEtBQUssR0FBRyxFQUFFLENBQUMsR0FBRyxDQUFDLElBQUksRUFBRTtTQUN0QixLQUFLLENBQUMsQ0FBQyxDQUFDO1NBQ1IsTUFBTSxDQUFDLFFBQVEsQ0FBQztTQUNoQixVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7U0FDdEIsVUFBVSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztJQUM5QixFQUFFLENBQUMsTUFBTSxDQUFDLGtCQUFrQixDQUFDLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQztTQUN0QyxJQUFJLENBQUMsT0FBTyxFQUFFLFFBQVEsQ0FBQztTQUN2QixJQUFJLENBQUMsV0FBVyxFQUFFLGlCQUFpQixDQUFDO1NBQ3BDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztJQUlmLE1BQU0sQ0FBQyxnQkFBZ0IsQ0FBQyxRQUFRLEVBQUU7UUFDaEMsSUFBSSxRQUFRLEdBQUcsUUFBUSxDQUFDLGFBQWEsQ0FBQyxZQUFZLENBQUM7YUFDOUMscUJBQXFCLEVBQUUsQ0FBQyxLQUFLLENBQUM7UUFDbkMsRUFBRSxDQUFDLENBQUMsUUFBUSxLQUFLLFNBQVMsQ0FBQyxDQUFDLENBQUM7WUFDM0IsU0FBUyxHQUFHLFFBQVEsQ0FBQztZQUNyQixXQUFXLENBQUMsT0FBTyxDQUFDLENBQUM7WUFDckIsUUFBUSxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQ2pCLENBQUM7SUFDSCxDQUFDLENBQUMsQ0FBQztBQUNMLENBQUM7QUFFRCx3QkFBd0IsT0FBb0I7SUFDMUMsRUFBRSxDQUFDLFdBQVcsQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFLFVBQUEsSUFBSTtRQUNoQyxFQUFFLENBQUMsTUFBTSxDQUFDLGVBQWEsSUFBSSxDQUFDLEVBQUksQ0FBQyxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUUsVUFBVSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO0lBQ3pFLENBQUMsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVELHlCQUF5QixPQUFvQixFQUFFLFNBQTRCO0lBQ3pFLEdBQUcsQ0FBQyxDQUFDLElBQUksUUFBUSxHQUFHLENBQUMsRUFBRSxRQUFRLEdBQUcsT0FBTyxDQUFDLE1BQU0sRUFBRSxRQUFRLEVBQUUsRUFBRSxDQUFDO1FBQzdELElBQUksWUFBWSxHQUFHLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQztRQUVyQyxHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLFlBQVksQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUM3QyxJQUFJLElBQUksR0FBRyxZQUFZLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDM0IsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO2dCQUNoRCxJQUFJLElBQUksR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUM5QixTQUFTLENBQUMsTUFBTSxDQUFDLFVBQVEsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLFNBQUksSUFBSSxDQUFDLElBQUksQ0FBQyxFQUFJLENBQUM7cUJBQ3JELEtBQUssQ0FBQztvQkFDTCxtQkFBbUIsRUFBRSxDQUFDLElBQUksR0FBRyxDQUFDO29CQUM5QixjQUFjLEVBQUUsY0FBYyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDO29CQUNyRCxRQUFRLEVBQUUsVUFBVSxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUM7aUJBQ2xDLENBQUM7cUJBQ0QsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO1lBQ25CLENBQUM7UUFDSCxDQUFDO0lBQ0gsQ0FBQztBQUNILENBQUM7QUFFRCxrQkFBa0IsRUFBVSxFQUFFLEVBQVUsRUFBRSxNQUFjLEVBQUUsT0FBZ0IsRUFDdEUsU0FBNEIsRUFBRSxJQUFjO0lBQzlDLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxTQUFTLEdBQUcsQ0FBQyxDQUFDO0lBQzNCLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxTQUFTLEdBQUcsQ0FBQyxDQUFDO0lBRTNCLElBQUksU0FBUyxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDO1NBQ2xDLElBQUksQ0FBQztRQUNKLE9BQU8sRUFBRSxNQUFNO1FBQ2YsSUFBSSxFQUFFLFNBQU8sTUFBUTtRQUNyQixXQUFXLEVBQUUsZUFBYSxDQUFDLFNBQUksQ0FBQyxNQUFHO0tBQ3BDLENBQUMsQ0FBQztJQUdMLFNBQVMsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDO1NBQ3JCLElBQUksQ0FBQztRQUNKLENBQUMsRUFBRSxDQUFDO1FBQ0osQ0FBQyxFQUFFLENBQUM7UUFDSixLQUFLLEVBQUUsU0FBUztRQUNoQixNQUFNLEVBQUUsU0FBUztLQUNsQixDQUFDLENBQUM7SUFDTCxJQUFJLGdCQUFnQixHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUMsR0FBRyxRQUFRLEdBQUcsVUFBVSxDQUFDO0lBQzdELEVBQUUsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDWixJQUFJLEtBQUssR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsS0FBSyxJQUFJLElBQUk7WUFDcEMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLEtBQUssR0FBRyxNQUFNLENBQUM7UUFFbEMsSUFBSSxJQUFJLEdBQUcsU0FBUyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxJQUFJLENBQUM7WUFDdkMsS0FBSyxFQUFFLFlBQVk7WUFDbkIsQ0FBQyxFQUFFLENBQUMsRUFBRTtZQUNOLENBQUMsRUFBRSxTQUFTLEdBQUcsQ0FBQyxFQUFFLGFBQWEsRUFBRSxLQUFLO1NBQ3ZDLENBQUMsQ0FBQztRQUNILEVBQUUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3ZCLElBQUksSUFBSSxHQUFHLGlCQUFpQixDQUFDO1lBQzdCLElBQUksT0FBTyxTQUFBLENBQUM7WUFDWixJQUFJLFNBQVMsU0FBQSxDQUFDO1lBQ2QsT0FBTyxDQUFDLE9BQU8sR0FBRyxJQUFJLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLEtBQUssSUFBSSxFQUFFLENBQUM7Z0JBQzdDLFNBQVMsR0FBRyxJQUFJLENBQUMsU0FBUyxDQUFDO2dCQUMzQixJQUFJLE1BQU0sR0FBRyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUM7Z0JBQ3hCLElBQUksR0FBRyxHQUFHLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDckIsSUFBSSxNQUFNLEdBQUcsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUN4QixFQUFFLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO29CQUNYLElBQUksQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDO2dCQUNwQyxDQUFDO2dCQUNELElBQUksQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDO3FCQUNuQixJQUFJLENBQUMsZ0JBQWdCLEVBQUUsR0FBRyxJQUFJLEdBQUcsR0FBRyxLQUFLLEdBQUcsT0FBTyxDQUFDO3FCQUNwRCxLQUFLLENBQUMsV0FBVyxFQUFFLEtBQUssQ0FBQztxQkFDekIsSUFBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQ2hCLENBQUM7WUFDRCxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDL0IsSUFBSSxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDO1lBQ3hELENBQUM7UUFDSCxDQUFDO1FBQUMsSUFBSSxDQUFDLENBQUM7WUFDTixJQUFJLENBQUMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNuQyxDQUFDO1FBQ0QsU0FBUyxDQUFDLE9BQU8sQ0FBQyxnQkFBZ0IsRUFBRSxJQUFJLENBQUMsQ0FBQztJQUM1QyxDQUFDO0lBQ0QsRUFBRSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBRWIsU0FBUyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUM7YUFDckIsSUFBSSxDQUFDO1lBQ0osRUFBRSxFQUFFLFVBQVEsTUFBUTtZQUNwQixDQUFDLEVBQUUsQ0FBQyxTQUFTLEdBQUcsQ0FBQztZQUNqQixDQUFDLEVBQUUsU0FBUyxHQUFHLFNBQVMsR0FBRyxDQUFDO1lBQzVCLEtBQUssRUFBRSxTQUFTO1lBQ2hCLE1BQU0sRUFBRSxTQUFTO1NBQ2xCLENBQUMsQ0FBQyxFQUFFLENBQUMsWUFBWSxFQUFFO1lBQ2xCLGVBQWUsQ0FBQyxTQUFTLENBQUMsSUFBSSxFQUFFLElBQUksRUFBRSxFQUFFLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDcEUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLFlBQVksRUFBRTtZQUNsQixlQUFlLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDeEIsQ0FBQyxDQUFDLENBQUM7SUFDUCxDQUFDO0lBR0QsSUFBSSxHQUFHLEdBQUcsRUFBRSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxFQUFFLGNBQWMsQ0FBQztTQUMxRCxJQUFJLENBQUM7UUFDSixJQUFJLEVBQUUsWUFBVSxNQUFRO1FBQ3hCLE9BQU8sRUFBRSxRQUFRO0tBQ2xCLENBQUM7U0FDRCxLQUFLLENBQUM7UUFDTCxRQUFRLEVBQUUsVUFBVTtRQUNwQixJQUFJLEVBQUUsQ0FBRyxDQUFDLEdBQUcsQ0FBQyxRQUFJO1FBQ2xCLEdBQUcsRUFBRSxDQUFHLENBQUMsR0FBRyxDQUFDLFFBQUk7S0FDbEIsQ0FBQztTQUNELEVBQUUsQ0FBQyxZQUFZLEVBQUU7UUFDaEIsY0FBYyxHQUFHLE1BQU0sQ0FBQztRQUN4QixHQUFHLENBQUMsT0FBTyxDQUFDLFNBQVMsRUFBRSxJQUFJLENBQUMsQ0FBQztRQUM3QixTQUFTLENBQUMsT0FBTyxDQUFDLFNBQVMsRUFBRSxJQUFJLENBQUMsQ0FBQztRQUNuQyxzQkFBc0IsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLENBQUM7UUFDdkMsT0FBTyxDQUFDLGdCQUFnQixDQUFDLFFBQVEsQ0FBQyxNQUFNLENBQUMsRUFBRSxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDL0QsQ0FBQyxDQUFDO1NBQ0QsRUFBRSxDQUFDLFlBQVksRUFBRTtRQUNoQixjQUFjLEdBQUcsSUFBSSxDQUFDO1FBQ3RCLEdBQUcsQ0FBQyxPQUFPLENBQUMsU0FBUyxFQUFFLEtBQUssQ0FBQyxDQUFDO1FBQzlCLFNBQVMsQ0FBQyxPQUFPLENBQUMsU0FBUyxFQUFFLEtBQUssQ0FBQyxDQUFDO1FBQ3BDLHNCQUFzQixDQUFDLE9BQU8sRUFBRSxLQUFLLENBQUMsQ0FBQztRQUN2QyxPQUFPLENBQUMsZ0JBQWdCLENBQUMsUUFBUSxDQUFDLEVBQUUsQ0FBQyxhQUFhLENBQUMsT0FBTyxDQUFDLENBQUMsRUFBRSxDQUFDLEVBQzNELEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUN4QixDQUFDLENBQUMsQ0FBQztJQUNMLEVBQUUsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDWixHQUFHLENBQUMsRUFBRSxDQUFDLE9BQU8sRUFBRTtZQUNkLEtBQUssQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsQ0FBQztZQUMvQixLQUFLLEVBQUUsQ0FBQztRQUNWLENBQUMsQ0FBQyxDQUFDO1FBQ0gsR0FBRyxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDakMsQ0FBQztJQUNELEVBQUUsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDWixHQUFHLENBQUMsT0FBTyxDQUFDLGdCQUFnQixFQUFFLElBQUksQ0FBQyxDQUFDO0lBQ3RDLENBQUM7SUFDRCxJQUFJLFdBQVcsR0FBRyxJQUFJLGlCQUFPLENBQUMsU0FBUyxFQUFFLE9BQU8sR0FBRyxFQUFFLEVBQUUsT0FBTyxFQUMxRCxPQUFPLEVBQUUsR0FBRyxFQUFFLEVBQUMsS0FBSyxFQUFFLElBQUksRUFBQyxDQUFDLENBQUM7SUFDakMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFDLE9BQU8sRUFBRSxXQUFXLEVBQUUsRUFBRSxFQUFFLE1BQU0sRUFBQyxDQUFDLENBQUM7QUFFaEQsQ0FBQztBQUdELHFCQUFxQixPQUFvQjtJQUN2QyxJQUFJLEdBQUcsR0FBRyxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBRTVCLEdBQUcsQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDLENBQUMsTUFBTSxFQUFFLENBQUM7SUFFOUIsRUFBRSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxTQUFTLENBQUMsWUFBWSxDQUFDLENBQUMsTUFBTSxFQUFFLENBQUM7SUFDdkQsRUFBRSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxTQUFTLENBQUMsd0JBQXdCLENBQUMsQ0FBQyxNQUFNLEVBQUUsQ0FBQztJQUduRSxJQUFJLE9BQU8sR0FBRyxDQUFDLENBQUM7SUFDaEIsSUFBSSxFQUFFLEdBQW9CLEVBQUUsQ0FBQyxNQUFNLENBQUMsZ0JBQWdCLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUM3RCxJQUFJLEVBQUUsR0FBb0IsRUFBRSxDQUFDLE1BQU0sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDLElBQUksRUFBRSxDQUFDO0lBQy9ELElBQUksS0FBSyxHQUFHLEVBQUUsQ0FBQyxVQUFVLEdBQUcsRUFBRSxDQUFDLFVBQVUsQ0FBQztJQUMxQyxHQUFHLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxLQUFLLENBQUMsQ0FBQztJQUd6QixJQUFJLFVBQVUsR0FBNkMsRUFBRSxDQUFDO0lBQzlELElBQUksU0FBUyxHQUFHLEdBQUcsQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDO1NBQzVCLE9BQU8sQ0FBQyxNQUFNLEVBQUUsSUFBSSxDQUFDO1NBQ3JCLElBQUksQ0FBQyxXQUFXLEVBQUUsZUFBYSxPQUFPLFNBQUksT0FBTyxNQUFHLENBQUMsQ0FBQztJQUV6RCxJQUFJLFNBQVMsR0FBRyxPQUFPLENBQUMsTUFBTSxDQUFDO0lBQy9CLElBQUksWUFBWSxHQUFHLEdBQUcsQ0FBQztJQUN2QixJQUFJLFVBQVUsR0FBRyxFQUFFLENBQUMsS0FBSyxDQUFDLE9BQU8sRUFBa0I7U0FDOUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLFNBQVMsR0FBRyxDQUFDLENBQUMsQ0FBQztTQUNsQyxXQUFXLENBQUMsQ0FBQyxZQUFZLEVBQUUsS0FBSyxHQUFHLFNBQVMsQ0FBQyxFQUFFLEdBQUcsQ0FBQyxDQUFDO0lBQ3pELElBQUksY0FBYyxHQUFHLFVBQUMsU0FBaUIsSUFBSyxPQUFBLFNBQVMsR0FBRyxDQUFDLFNBQVMsR0FBRyxFQUFFLENBQUMsRUFBNUIsQ0FBNEIsQ0FBQztJQUd6RSxJQUFJLFlBQVksR0FBRyxFQUFFLENBQUMsTUFBTSxDQUFDLG9CQUFvQixDQUFDLENBQUMsS0FBSyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUM1RSxJQUFJLGNBQWMsR0FBRyxFQUFFLENBQUMsTUFBTSxDQUFDLGtCQUFrQixDQUFDLENBQUMsS0FBSyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUM1RSxJQUFJLGFBQWEsR0FBRyxJQUFJLENBQUM7SUFDekIsSUFBSSxtQkFBbUIsR0FBRyxJQUFJLENBQUM7SUFHL0IsSUFBSSxFQUFFLEdBQUcsU0FBUyxHQUFHLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDNUIsSUFBSSxPQUFPLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUNsQyxJQUFJLElBQUksR0FBRyxjQUFjLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQzFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsVUFBQyxNQUFNLEVBQUUsQ0FBQztRQUN4QixJQUFJLEVBQUUsR0FBRyxjQUFjLENBQUMsQ0FBQyxDQUFDLEdBQUcsU0FBUyxHQUFHLENBQUMsQ0FBQztRQUMzQyxVQUFVLENBQUMsTUFBTSxDQUFDLEdBQUcsRUFBQyxFQUFFLEVBQUUsRUFBRSxFQUFFLEVBQUUsRUFBRSxFQUFFLEVBQUMsQ0FBQztRQUN0QyxRQUFRLENBQUMsRUFBRSxFQUFFLEVBQUUsRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLFNBQVMsQ0FBQyxDQUFDO0lBQzVDLENBQUMsQ0FBQyxDQUFDO0lBR0gsR0FBRyxDQUFDLENBQUMsSUFBSSxRQUFRLEdBQUcsQ0FBQyxFQUFFLFFBQVEsR0FBRyxTQUFTLEdBQUcsQ0FBQyxFQUFFLFFBQVEsRUFBRSxFQUFFLENBQUM7UUFDNUQsSUFBSSxRQUFRLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLE1BQU0sQ0FBQztRQUN4QyxJQUFJLElBQUUsR0FBRyxVQUFVLENBQUMsUUFBUSxDQUFDLEdBQUcsU0FBUyxHQUFHLENBQUMsQ0FBQztRQUM5QyxJQUFJLEdBQUcsSUFBSSxDQUFDLEdBQUcsQ0FBQyxJQUFJLEVBQUUsY0FBYyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7UUFDaEQsbUJBQW1CLENBQUMsVUFBVSxDQUFDLFFBQVEsQ0FBQyxFQUFFLFFBQVEsQ0FBQyxDQUFDO1FBQ3BELEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsUUFBUSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7WUFDbEMsSUFBSSxNQUFJLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2hDLElBQUksSUFBRSxHQUFHLGNBQWMsQ0FBQyxDQUFDLENBQUMsR0FBRyxTQUFTLEdBQUcsQ0FBQyxDQUFDO1lBQzNDLFVBQVUsQ0FBQyxNQUFJLENBQUMsRUFBRSxDQUFDLEdBQUcsRUFBQyxFQUFFLEVBQUUsSUFBRSxFQUFFLEVBQUUsRUFBRSxJQUFFLEVBQUMsQ0FBQztZQUN2QyxRQUFRLENBQUMsSUFBRSxFQUFFLElBQUUsRUFBRSxNQUFJLENBQUMsRUFBRSxFQUFFLEtBQUssRUFBRSxTQUFTLEVBQUUsTUFBSSxDQUFDLENBQUM7WUFHbEQsSUFBSSxVQUFRLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLE1BQU0sQ0FBQztZQUN4QyxJQUFJLFlBQVksR0FBRyxPQUFPLENBQUMsUUFBUSxHQUFHLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQztZQUNoRCxFQUFFLENBQUMsQ0FBQyxhQUFhLElBQUksSUFBSTtnQkFDckIsQ0FBQyxLQUFLLFVBQVEsR0FBRyxDQUFDO2dCQUNsQixZQUFZLElBQUksVUFBUSxDQUFDLENBQUMsQ0FBQztnQkFDN0IsWUFBWSxDQUFDLEtBQUssQ0FBQztvQkFDakIsT0FBTyxFQUFFLElBQUk7b0JBQ2IsR0FBRyxFQUFFLENBQUcsRUFBRSxHQUFHLENBQUMsR0FBRyxJQUFFLFFBQUk7b0JBQ3ZCLElBQUksRUFBSyxJQUFFLE9BQUk7aUJBQ2hCLENBQUMsQ0FBQztnQkFDSCxhQUFhLEdBQUcsTUFBSSxDQUFDLEVBQUUsQ0FBQztZQUMxQixDQUFDO1lBR0QsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFJLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO2dCQUNoRCxJQUFJLElBQUksR0FBRyxNQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDO2dCQUM5QixJQUFJLElBQUksR0FBeUIsUUFBUSxDQUFDLElBQUksRUFBRSxVQUFVLEVBQUUsT0FBTyxFQUMvRCxTQUFTLEVBQUUsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDLEVBQUUsTUFBSSxDQUFDLFVBQVUsQ0FBQyxNQUFNLENBQUMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztnQkFFMUQsSUFBSSxTQUFTLEdBQUcsT0FBTyxDQUFDLFFBQVEsR0FBRyxDQUFDLENBQUMsQ0FBQztnQkFDdEMsSUFBSSxpQkFBaUIsR0FBRyxTQUFTLENBQUMsU0FBUyxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQztnQkFDeEQsRUFBRSxDQUFDLENBQUMsbUJBQW1CLElBQUksSUFBSTtvQkFDM0IsQ0FBQyxLQUFLLFVBQVEsR0FBRyxDQUFDO29CQUNsQixJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsS0FBSyxpQkFBaUIsQ0FBQyxFQUFFO29CQUN2QyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsRUFBRSxLQUFLLGFBQWEsSUFBSSxTQUFTLElBQUksQ0FBQyxDQUFDO29CQUNwRCxJQUFJLENBQUMsSUFBSSxDQUFDLEVBQUUsS0FBSyxhQUFhO29CQUM5QixTQUFTLENBQUMsTUFBTSxJQUFJLFVBQVEsQ0FBQyxDQUFDLENBQUM7b0JBQ2pDLElBQUksUUFBUSxHQUFHLElBQUksQ0FBQyxnQkFBZ0IsQ0FBQyxJQUFJLENBQUMsY0FBYyxFQUFFLEdBQUcsR0FBRyxDQUFDLENBQUM7b0JBQ2xFLGNBQWMsQ0FBQyxLQUFLLENBQUM7d0JBQ25CLE9BQU8sRUFBRSxJQUFJO3dCQUNiLEdBQUcsRUFBRSxDQUFHLFFBQVEsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxRQUFJO3dCQUMxQixJQUFJLEVBQUUsQ0FBRyxRQUFRLENBQUMsQ0FBQyxHQUFHLENBQUMsUUFBSTtxQkFDNUIsQ0FBQyxDQUFDO29CQUNILG1CQUFtQixHQUFHLElBQUksQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO2dCQUNyQyxDQUFDO1lBQ0gsQ0FBQztRQUNILENBQUM7SUFDSCxDQUFDO0lBR0QsRUFBRSxHQUFHLEtBQUssR0FBRyxTQUFTLEdBQUcsQ0FBQyxDQUFDO0lBQzNCLElBQUksSUFBSSxHQUFHLE9BQU8sQ0FBQyxTQUFTLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDckMsSUFBSSxFQUFFLEdBQUcsY0FBYyxDQUFDLENBQUMsQ0FBQyxHQUFHLFNBQVMsR0FBRyxDQUFDLENBQUM7SUFDM0MsVUFBVSxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsR0FBRyxFQUFDLEVBQUUsRUFBRSxFQUFFLEVBQUUsRUFBRSxFQUFFLEVBQUUsRUFBQyxDQUFDO0lBRXZDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsSUFBSSxDQUFDLFVBQVUsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztRQUNoRCxJQUFJLElBQUksR0FBRyxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzlCLFFBQVEsQ0FBQyxJQUFJLEVBQUUsVUFBVSxFQUFFLE9BQU8sRUFBRSxTQUFTLEVBQUUsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDLEVBQ3JELElBQUksQ0FBQyxVQUFVLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDOUIsQ0FBQztJQUVELEdBQUcsQ0FBQyxJQUFJLENBQUMsUUFBUSxFQUFFLElBQUksQ0FBQyxDQUFDO0lBR3pCLElBQUksTUFBTSxHQUFHLElBQUksQ0FBQyxHQUFHLENBQ25CLGlCQUFpQixDQUFDLFlBQVksQ0FBQyxFQUMvQixpQkFBaUIsQ0FBQyxjQUFjLENBQUMsRUFDakMsaUJBQWlCLENBQUMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUN6QyxDQUFDO0lBQ0YsRUFBRSxDQUFDLE1BQU0sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsTUFBTSxHQUFHLElBQUksQ0FBQyxDQUFDO0FBQy9ELENBQUM7QUFFRCwyQkFBMkIsU0FBNEI7SUFDckQsSUFBSSxJQUFJLEdBQXVCLFNBQVMsQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUNoRCxNQUFNLENBQUMsSUFBSSxDQUFDLFlBQVksR0FBRyxJQUFJLENBQUMsU0FBUyxDQUFDO0FBQzVDLENBQUM7QUFFRCw2QkFBNkIsQ0FBUyxFQUFFLFFBQWdCO0lBQ3RELElBQUksR0FBRyxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQztTQUMxQyxPQUFPLENBQUMsb0JBQW9CLEVBQUUsSUFBSSxDQUFDO1NBQ25DLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBRyxDQUFDLEdBQUcsRUFBRSxRQUFJLENBQUMsQ0FBQztJQUVoQyxJQUFJLENBQUMsR0FBRyxRQUFRLEdBQUcsQ0FBQyxDQUFDO0lBQ3JCLElBQUksUUFBUSxHQUFHLEdBQUcsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxnQkFBYyxRQUFVLENBQUMsQ0FBQztJQUN6RSxRQUFRLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQztTQUNwQixJQUFJLENBQUMsT0FBTyxFQUFFLDJDQUEyQyxDQUFDO1NBQzFELEVBQUUsQ0FBQyxPQUFPLEVBQUU7UUFDWCxJQUFJLFVBQVUsR0FBRyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3ZDLEVBQUUsQ0FBQyxDQUFDLFVBQVUsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3BCLE1BQU0sQ0FBQztRQUNULENBQUM7UUFDRCxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7UUFDeEIsS0FBSyxFQUFFLENBQUM7SUFDVixDQUFDLENBQUM7U0FDSCxNQUFNLENBQUMsR0FBRyxDQUFDO1NBQ1QsSUFBSSxDQUFDLE9BQU8sRUFBRSxnQkFBZ0IsQ0FBQztTQUMvQixJQUFJLENBQUMsS0FBSyxDQUFDLENBQUM7SUFFakIsUUFBUSxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUM7U0FDcEIsSUFBSSxDQUFDLE9BQU8sRUFBRSwyQ0FBMkMsQ0FBQztTQUMxRCxFQUFFLENBQUMsT0FBTyxFQUFFO1FBQ1gsSUFBSSxVQUFVLEdBQUcsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUN2QyxFQUFFLENBQUMsQ0FBQyxVQUFVLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNwQixNQUFNLENBQUM7UUFDVCxDQUFDO1FBQ0QsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBQ3hCLEtBQUssRUFBRSxDQUFDO0lBQ1YsQ0FBQyxDQUFDO1NBQ0gsTUFBTSxDQUFDLEdBQUcsQ0FBQztTQUNULElBQUksQ0FBQyxPQUFPLEVBQUUsZ0JBQWdCLENBQUM7U0FDL0IsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBRXBCLElBQUksTUFBTSxHQUFHLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLEdBQUcsR0FBRyxFQUFFLENBQUM7SUFDbEQsR0FBRyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxJQUFJLENBQ3BCLEtBQUssQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLEdBQUcsU0FBUyxHQUFHLE1BQU0sQ0FDM0MsQ0FBQztBQUNKLENBQUM7QUFFRCx5QkFBeUIsSUFBZSxFQUFFLFVBQThCLEVBQ3BFLFdBQThCO0lBQ2hDLElBQUksU0FBUyxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7SUFDeEMsRUFBRSxDQUFDLENBQUMsSUFBSSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUM7UUFDakIsU0FBUyxDQUFDLEtBQUssQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7UUFDbkMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxFQUFFLENBQUMsT0FBTyxFQUFFLElBQUksQ0FBQyxDQUFDO1FBQ3BDLE1BQU0sQ0FBQztJQUNULENBQUM7SUFDRCxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLEVBQUUsQ0FBQyxPQUFPLEVBQUU7UUFDNUIsU0FBUyxDQUFDLE1BQU0sQ0FBQyxRQUFRLENBQUMsQ0FBQyxLQUFLLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO1FBQ3BELElBQUksS0FBSyxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDdEMsS0FBSyxDQUFDLEtBQUssQ0FBQyxTQUFTLEVBQUUsSUFBSSxDQUFDLENBQUM7UUFDN0IsS0FBSyxDQUFDLEVBQUUsQ0FBQyxPQUFPLEVBQUU7WUFDaEIsRUFBRSxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssSUFBSSxJQUFJLElBQUksSUFBSSxDQUFDLEtBQUssS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDO2dCQUM1QyxFQUFFLENBQUMsQ0FBQyxJQUFJLElBQUksU0FBUyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7b0JBQ25CLFVBQVcsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDO2dCQUM3QyxDQUFDO2dCQUFDLElBQUksQ0FBQyxDQUFDO29CQUNJLFVBQVcsQ0FBQyxJQUFJLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDO2dCQUMzQyxDQUFDO2dCQUNELFFBQVEsRUFBRSxDQUFDO1lBQ2IsQ0FBQztRQUNILENBQUMsQ0FBQyxDQUFDO1FBQ0gsS0FBSyxDQUFDLEVBQUUsQ0FBQyxVQUFVLEVBQUU7WUFDbkIsRUFBRSxDQUFDLENBQU8sRUFBRSxDQUFDLEtBQU0sQ0FBQyxPQUFPLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQztnQkFDbEMsZUFBZSxDQUFDLElBQUksRUFBRSxVQUFVLEVBQUUsV0FBVyxDQUFDLENBQUM7WUFDakQsQ0FBQztRQUNILENBQUMsQ0FBQyxDQUFDO1FBQ2dCLEtBQUssQ0FBQyxJQUFJLEVBQUcsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUMzQyxDQUFDLENBQUMsQ0FBQztJQUNILElBQUksS0FBSyxHQUFHLElBQUksSUFBSSxTQUFTLENBQUMsTUFBTTtRQUN4QixVQUFXLENBQUMsTUFBTTtRQUNsQixVQUFXLENBQUMsSUFBSSxDQUFDO0lBQzdCLElBQUksSUFBSSxHQUFHLElBQUksSUFBSSxTQUFTLENBQUMsTUFBTSxHQUFHLFFBQVEsR0FBRyxNQUFNLENBQUM7SUFDeEQsU0FBUyxDQUFDLEtBQUssQ0FBQztRQUNkLE1BQU0sRUFBRSxDQUFHLFdBQVcsQ0FBQyxDQUFDLENBQUMsR0FBRyxFQUFFLFFBQUk7UUFDbEMsS0FBSyxFQUFLLFdBQVcsQ0FBQyxDQUFDLENBQUMsT0FBSTtRQUM1QixTQUFTLEVBQUUsT0FBTztLQUNuQixDQUFDLENBQUM7SUFDSCxTQUFTLENBQUMsTUFBTSxDQUFDLE9BQU8sQ0FBQyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNyQyxTQUFTLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQztTQUN2QixLQUFLLENBQUMsU0FBUyxFQUFFLElBQUksQ0FBQztTQUN0QixJQUFJLENBQUMsS0FBSyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQzlCLFNBQVMsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDO1NBQ3RCLFFBQVEsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLFdBQVcsQ0FBQyxDQUFDLENBQUMsQ0FBQztTQUN2QyxLQUFLLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0FBQzlCLENBQUM7QUFFRCxrQkFDSSxLQUFjLEVBQUUsVUFBb0QsRUFDcEUsT0FBb0IsRUFBRSxTQUE0QixFQUNsRCxPQUFnQixFQUFFLEtBQWEsRUFBRSxNQUFjO0lBQ2pELElBQUksSUFBSSxHQUFHLFNBQVMsQ0FBQyxNQUFNLENBQUMsTUFBTSxFQUFFLGNBQWMsQ0FBQyxDQUFDO0lBQ3BELElBQUksTUFBTSxHQUFHLFVBQVUsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ3pDLElBQUksSUFBSSxHQUFHLFVBQVUsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQ3JDLElBQUksS0FBSyxHQUFHO1FBQ1YsTUFBTSxFQUFFO1lBQ04sQ0FBQyxFQUFFLE1BQU0sQ0FBQyxFQUFFLEdBQUcsU0FBUyxHQUFHLENBQUMsR0FBRyxDQUFDO1lBQ2hDLENBQUMsRUFBRSxNQUFNLENBQUMsRUFBRTtTQUNiO1FBQ0QsTUFBTSxFQUFFO1lBQ04sQ0FBQyxFQUFFLElBQUksQ0FBQyxFQUFFLEdBQUcsU0FBUyxHQUFHLENBQUM7WUFDMUIsQ0FBQyxFQUFFLElBQUksQ0FBQyxFQUFFLEdBQUcsQ0FBQyxDQUFDLEtBQUssR0FBRyxDQUFDLE1BQU0sR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxNQUFNLENBQUMsR0FBRyxFQUFFO1NBQ3hEO0tBQ0YsQ0FBQztJQUNGLElBQUksUUFBUSxHQUFHLEVBQUUsQ0FBQyxHQUFHLENBQUMsUUFBUSxFQUFFLENBQUMsVUFBVSxDQUFDLFVBQUEsQ0FBQyxJQUFJLE9BQUEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBVixDQUFVLENBQUMsQ0FBQztJQUM3RCxJQUFJLENBQUMsSUFBSSxDQUFDO1FBQ1IsY0FBYyxFQUFFLG1CQUFtQjtRQUNuQyxLQUFLLEVBQUUsTUFBTTtRQUNiLEVBQUUsRUFBRSxNQUFNLEdBQUcsS0FBSyxDQUFDLE1BQU0sQ0FBQyxFQUFFLEdBQUcsR0FBRyxHQUFHLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRTtRQUNsRCxDQUFDLEVBQUUsUUFBUSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUM7S0FDdEIsQ0FBQyxDQUFDO0lBSUgsU0FBUyxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUM7U0FDckIsSUFBSSxDQUFDLEdBQUcsRUFBRSxRQUFRLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDO1NBQzdCLElBQUksQ0FBQyxPQUFPLEVBQUUsWUFBWSxDQUFDO1NBQzNCLEVBQUUsQ0FBQyxZQUFZLEVBQUU7UUFDaEIsZUFBZSxDQUFDLFNBQVMsQ0FBQyxNQUFNLEVBQUUsS0FBSyxFQUFFLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQztJQUMzRCxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsWUFBWSxFQUFFO1FBQ2xCLGVBQWUsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUN4QixDQUFDLENBQUMsQ0FBQztJQUNMLE1BQU0sQ0FBQyxJQUFJLENBQUM7QUFDZCxDQUFDO0FBUUQsZ0NBQWdDLE9BQW9CLEVBQUUsU0FBa0I7SUFDdEUsRUFBRSxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQztRQUNkLFFBQVEsR0FBRyxFQUFFLENBQUM7UUFDZCxFQUFFLENBQUMsV0FBVyxDQUFDLE9BQU8sRUFBRSxJQUFJLEVBQUUsVUFBQSxJQUFJO1lBQ2hDLFFBQVEsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLEdBQUcsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDekMsQ0FBQyxDQUFDLENBQUM7UUFFSCxHQUFHLENBQUMsQ0FBQyxJQUFJLE1BQU0sSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDO1lBQzFCLFFBQVEsQ0FBQyxNQUFNLENBQUMsR0FBRyxJQUFJLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUN4QyxDQUFDO0lBQ0gsQ0FBQztJQUNELElBQUksTUFBTSxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFLE9BQU8sR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUN2RSxJQUFJLE1BQU0sR0FBRyxFQUFFLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDLE1BQU0sQ0FBQyxDQUFDLE9BQU8sR0FBRyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUM7SUFFdkUsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDakIsR0FBRyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsT0FBTyxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDN0IsRUFBRSxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQztZQUNkLEVBQUUsQ0FBQyxXQUFXLENBQUMsT0FBTyxFQUFFLElBQUksRUFBRSxVQUFBLElBQUk7Z0JBQ2hDLFFBQVEsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUM7WUFDNUMsQ0FBQyxDQUFDLENBQUM7WUFFSCxHQUFHLENBQUMsQ0FBQyxJQUFJLE1BQU0sSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDO2dCQUMxQixRQUFRLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsSUFBSSxLQUFLLENBQUMsT0FBTyxDQUFDLENBQUM7WUFDM0MsQ0FBQztRQUNILENBQUM7UUFDRCxHQUFHLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxPQUFPLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQztZQUU3QixJQUFJLENBQUMsR0FBRyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEIsSUFBSSxDQUFDLEdBQUcsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2xCLElBQUksS0FBSyxHQUFHLGNBQWMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7WUFDakMsRUFBRSxDQUFDLFdBQVcsQ0FBQyxPQUFPLEVBQUUsS0FBSyxDQUFDLENBQUM7WUFDL0IsRUFBRSxDQUFDLFdBQVcsQ0FBQyxPQUFPLEVBQUUsSUFBSSxFQUFFLFVBQUEsSUFBSTtnQkFDaEMsUUFBUSxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsR0FBRyxJQUFJLENBQUMsTUFBTSxDQUFDO1lBQ3hDLENBQUMsQ0FBQyxDQUFDO1lBQ0gsRUFBRSxDQUFDLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQztnQkFFZCxHQUFHLENBQUMsQ0FBQyxJQUFJLE1BQU0sSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDO29CQUMxQixRQUFRLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7Z0JBQ2xELENBQUM7WUFDSCxDQUFDO1FBQ0gsQ0FBQztJQUNILENBQUM7QUFDSCxDQUFDO0FBRUQsaUJBQWlCLE9BQW9CLEVBQUUsVUFBdUI7SUFDNUQsSUFBSSxJQUFJLEdBQUcsQ0FBQyxDQUFDO0lBQ2IsR0FBRyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxVQUFVLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7UUFDM0MsSUFBSSxTQUFTLEdBQUcsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzlCLElBQUksS0FBSyxHQUFHLGNBQWMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxFQUFFLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUNyRCxJQUFJLE1BQU0sR0FBRyxFQUFFLENBQUMsV0FBVyxDQUFDLE9BQU8sRUFBRSxLQUFLLENBQUMsQ0FBQztRQUM1QyxJQUFJLElBQUksRUFBRSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRSxTQUFTLENBQUMsS0FBSyxDQUFDLENBQUM7SUFDMUQsQ0FBQztJQUNELE1BQU0sQ0FBQyxJQUFJLEdBQUcsVUFBVSxDQUFDLE1BQU0sQ0FBQztBQUNsQyxDQUFDO0FBRUQsa0JBQWtCLFNBQWlCO0lBQWpCLHlCQUFpQixHQUFqQixpQkFBaUI7SUFFakMsZUFBZSxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUMsTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUM7SUFFOUMsY0FBYyxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBRXhCLHNCQUFzQixDQUFDLE9BQU8sRUFBRSxTQUFTLENBQUMsQ0FBQztJQUMzQyxJQUFJLFVBQVUsR0FBRyxjQUFjLElBQUksSUFBSTtRQUNuQyxjQUFjLEdBQUcsRUFBRSxDQUFDLGFBQWEsQ0FBQyxPQUFPLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDbEQsT0FBTyxDQUFDLGdCQUFnQixDQUFDLFFBQVEsQ0FBQyxVQUFVLENBQUMsRUFBRSxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUM7SUFHakUsRUFBRSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxTQUFTLENBQUMsWUFBWSxDQUFDO1NBQ3hDLElBQUksQ0FBQyxVQUFTLElBQW9DO1FBQ3JELElBQUksQ0FBQyxPQUFPLENBQUMsZ0JBQWdCLENBQUMsc0JBQVksQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxFQUM3RCxLQUFLLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDeEIsQ0FBQyxDQUFDLENBQUM7SUFFSCxpQkFBaUIsQ0FBUztRQUN4QixJQUFJLEdBQUcsR0FBRyxRQUFRLENBQUM7UUFDbkIsTUFBTSxDQUFDLENBQUMsR0FBRyxHQUFHLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN0QyxDQUFDO0lBRUQsbUJBQW1CLENBQVM7UUFDMUIsTUFBTSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsdUJBQXVCLEVBQUUsR0FBRyxDQUFDLENBQUM7SUFDakQsQ0FBQztJQUVELHVCQUF1QixDQUFTO1FBQzlCLE1BQU0sQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ3RCLENBQUM7SUFHRCxFQUFFLENBQUMsTUFBTSxDQUFDLGFBQWEsQ0FBQyxDQUFDLElBQUksQ0FBQyxhQUFhLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQztJQUN4RCxFQUFFLENBQUMsTUFBTSxDQUFDLFlBQVksQ0FBQyxDQUFDLElBQUksQ0FBQyxhQUFhLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztJQUN0RCxFQUFFLENBQUMsTUFBTSxDQUFDLGNBQWMsQ0FBQyxDQUFDLElBQUksQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUN6RCxTQUFTLENBQUMsWUFBWSxDQUFDLENBQUMsU0FBUyxFQUFFLFFBQVEsQ0FBQyxDQUFDLENBQUM7QUFDaEQsQ0FBQztBQUVEO0lBQ0UsSUFBSSxNQUFNLEdBQWEsRUFBRSxDQUFDO0lBQzFCLEdBQUcsQ0FBQyxDQUFDLElBQUksU0FBUyxJQUFJLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDN0IsRUFBRSxDQUFDLENBQUMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNyQixNQUFNLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1FBQ3pCLENBQUM7SUFDSCxDQUFDO0lBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBRUQsd0JBQXdCLENBQVMsRUFBRSxDQUFTO0lBQzFDLElBQUksS0FBSyxHQUFhLEVBQUUsQ0FBQztJQUN6QixHQUFHLENBQUMsQ0FBQyxJQUFJLFNBQVMsSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDO1FBQzdCLEVBQUUsQ0FBQyxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDckIsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3hDLENBQUM7SUFDSCxDQUFDO0lBQ0QsTUFBTSxDQUFDLEtBQUssQ0FBQztBQUNmLENBQUM7QUFFRDtJQUNFLElBQUksRUFBRSxDQUFDO0lBQ1AsU0FBUyxDQUFDLE9BQU8sQ0FBQyxVQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3pCLElBQUksS0FBSyxHQUFHLGNBQWMsQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQztRQUM3QyxFQUFFLENBQUMsV0FBVyxDQUFDLE9BQU8sRUFBRSxLQUFLLENBQUMsQ0FBQztRQUMvQixFQUFFLENBQUMsUUFBUSxDQUFDLE9BQU8sRUFBRSxLQUFLLENBQUMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDcEQsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQUcsS0FBSyxDQUFDLFNBQVMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3BDLEVBQUUsQ0FBQyxhQUFhLENBQUMsT0FBTyxFQUFFLEtBQUssQ0FBQyxZQUFZLEVBQUUsS0FBSyxDQUFDLGtCQUFrQixDQUFDLENBQUM7UUFDMUUsQ0FBQztJQUNILENBQUMsQ0FBQyxDQUFDO0lBRUgsU0FBUyxHQUFHLE9BQU8sQ0FBQyxPQUFPLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDeEMsUUFBUSxHQUFHLE9BQU8sQ0FBQyxPQUFPLEVBQUUsUUFBUSxDQUFDLENBQUM7SUFDdEMsUUFBUSxFQUFFLENBQUM7QUFDYixDQUFDO0FBRUQsMEJBQWlDLE9BQW9CO0lBQ25ELElBQUksT0FBTyxHQUFhLEVBQUUsQ0FBQztJQUMzQixHQUFHLENBQUMsQ0FBQyxJQUFJLFFBQVEsR0FBRyxDQUFDLEVBQUUsUUFBUSxHQUFHLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLFFBQVEsRUFBRSxFQUFFLENBQUM7UUFDakUsSUFBSSxZQUFZLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBQ3JDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsWUFBWSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQzdDLElBQUksSUFBSSxHQUFHLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUMzQixHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7Z0JBQzdDLElBQUksTUFBTSxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUM7Z0JBQzdCLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDO1lBQzlCLENBQUM7UUFDSCxDQUFDO0lBQ0gsQ0FBQztJQUNELE1BQU0sQ0FBQyxPQUFPLENBQUM7QUFDakIsQ0FBQztBQWJlLHdCQUFnQixtQkFhL0IsQ0FBQTtBQUVELDBCQUEwQixPQUFvQixFQUFFLE9BQWlCO0lBQy9ELElBQUksR0FBRyxHQUFXLENBQUMsQ0FBQztJQUNwQixHQUFHLENBQUMsQ0FBQyxJQUFJLFFBQVEsR0FBRyxDQUFDLEVBQUUsUUFBUSxHQUFHLE9BQU8sQ0FBQyxNQUFNLEdBQUcsQ0FBQyxFQUFFLFFBQVEsRUFBRSxFQUFFLENBQUM7UUFDakUsSUFBSSxZQUFZLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBQ3JDLEdBQUcsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsWUFBWSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDO1lBQzdDLElBQUksSUFBSSxHQUFHLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUMzQixHQUFHLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUM7Z0JBQzdDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsTUFBTSxHQUFHLE9BQU8sQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDO1lBQzFDLENBQUM7UUFDSCxDQUFDO0lBQ0gsQ0FBQztBQUNILENBQUM7QUFFRDtJQUNFLFNBQVMsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNsQixLQUFLLENBQUMsU0FBUyxFQUFFLENBQUM7SUFDbEIsTUFBTSxDQUFDLEtBQUssRUFBRSxDQUFDO0lBRWYsSUFBSSxNQUFNLEdBQUcsS0FBSyxDQUFDLGVBQWUsS0FBSyxDQUFDLEdBQUcsR0FBRyxHQUFHLEVBQUUsQ0FBQztJQUNwRCxFQUFFLENBQUMsTUFBTSxDQUFDLGVBQWUsQ0FBQyxDQUFDLElBQUksQ0FBQyxjQUFjLEdBQUcsTUFBTSxDQUFDLENBQUM7SUFDekQsRUFBRSxDQUFDLE1BQU0sQ0FBQyxhQUFhLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLGVBQWUsQ0FBQyxDQUFDO0lBR3JELElBQUksR0FBRyxDQUFDLENBQUM7SUFDVCxJQUFJLFNBQVMsR0FBRyxjQUFjLENBQUMsQ0FBQyxFQUFHLENBQUMsQ0FBQyxDQUFDLE1BQU0sQ0FBQztJQUM3QyxJQUFJLEtBQUssR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsWUFBWSxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUMvRCxJQUFJLGdCQUFnQixHQUFHLENBQUMsS0FBSyxDQUFDLE9BQU8sSUFBSSxlQUFPLENBQUMsVUFBVSxDQUFDO1FBQ3hELEVBQUUsQ0FBQyxXQUFXLENBQUMsTUFBTSxHQUFHLEVBQUUsQ0FBQyxXQUFXLENBQUMsSUFBSSxDQUFDO0lBQ2hELE9BQU8sR0FBRyxFQUFFLENBQUMsWUFBWSxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsVUFBVSxFQUFFLGdCQUFnQixFQUMvRCxLQUFLLENBQUMsY0FBYyxFQUFFLGlCQUFpQixFQUFFLENBQUMsQ0FBQztJQUMvQyxTQUFTLEdBQUcsT0FBTyxDQUFDLE9BQU8sRUFBRSxTQUFTLENBQUMsQ0FBQztJQUN4QyxRQUFRLEdBQUcsT0FBTyxDQUFDLE9BQU8sRUFBRSxRQUFRLENBQUMsQ0FBQztJQUN0QyxXQUFXLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDckIsUUFBUSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ2pCLENBQUM7QUFBQSxDQUFDO0FBRUY7SUFDRSxLQUFLLENBQUMsU0FBUyxFQUFFLENBQUM7SUFDbEIsSUFBSSxTQUFTLEdBQUcsY0FBYyxDQUFDLENBQUMsRUFBRyxDQUFDLENBQUMsQ0FBQyxNQUFNLENBQUM7SUFDN0MsSUFBSSxLQUFLLEdBQUcsQ0FBQyxTQUFTLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLFlBQVksQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDL0QsSUFBSSxnQkFBZ0IsR0FBRyxDQUFDLEtBQUssQ0FBQyxPQUFPLElBQUksZUFBTyxDQUFDLFVBQVUsQ0FBQztRQUN4RCxFQUFFLENBQUMsV0FBVyxDQUFDLE1BQU0sR0FBRyxFQUFFLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQztJQUNoRCxJQUFJLE9BQU8sR0FBRyxnQkFBZ0IsQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUN4QyxPQUFPLEdBQUcsRUFBRSxDQUFDLFlBQVksQ0FBQyxLQUFLLEVBQUUsS0FBSyxDQUFDLFVBQVUsRUFBRSxnQkFBZ0IsRUFDL0QsS0FBSyxDQUFDLGNBQWMsRUFBRSxpQkFBaUIsRUFBRSxDQUFDLENBQUM7SUFDL0MsZ0JBQWdCLENBQUMsT0FBTyxFQUFFLE9BQU8sQ0FBQyxDQUFDO0FBQ3JDLENBQUM7QUFBQSxDQUFDO0FBR0Y7SUFDRSxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsUUFBUSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUM7UUFDM0IsTUFBTSxDQUFDO0lBQ1QsQ0FBQztJQUVELEVBQUUsQ0FBQyxTQUFTLENBQUMscUJBQXFCLENBQUMsQ0FBQyxNQUFNLEVBQUUsQ0FBQztJQUM3QyxJQUFJLFFBQVEsR0FBRyxFQUFFLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUM7U0FDOUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxTQUFTLENBQUMsQ0FBQztJQUU1QixFQUFFLENBQUMsSUFBSSxDQUFDLGVBQWEsS0FBSyxDQUFDLFFBQVEsVUFBTyxFQUFFLFVBQUMsR0FBRyxFQUFFLFlBQVk7UUFDNUQsRUFBRSxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztZQUNSLE1BQU0sR0FBRyxDQUFDO1FBQ1osQ0FBQztRQUNLLFFBQVEsQ0FBQyxJQUFJLEVBQUcsQ0FBQyxXQUFXLENBQUMsWUFBWSxDQUFDLENBQUM7UUFFakQsSUFBSSxLQUFLLEdBQUcsUUFBUSxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQztRQUNyQyxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDO1lBQ2pCLEVBQUUsQ0FBQyxNQUFNLENBQUMsV0FBVyxDQUFDLENBQUMsS0FBSyxDQUFDO2dCQUMzQixZQUFZLEVBQUUsTUFBTTtnQkFDcEIsZUFBZSxFQUFFLE1BQU07YUFDeEIsQ0FBQztpQkFDRCxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUM7WUFDcEIsUUFBUSxDQUFDLEtBQUssR0FBRyxLQUFLLENBQUMsSUFBSSxFQUFFLENBQUM7UUFDaEMsQ0FBQztJQUNILENBQUMsQ0FBQyxDQUFDO0FBQ0wsQ0FBQztBQUVEO0lBQ0UseUJBQXlCLE1BQU0sRUFBRSxhQUFhO1FBQzVDLElBQUksQ0FBQyxHQUFHLEdBQUcsQ0FBQztRQUNaLElBQUksQ0FBQyxHQUFHLEdBQUcsQ0FBQztRQUNaLE1BQU0sQ0FBQyxZQUFZLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQ2hDLE1BQU0sQ0FBQyxZQUFZLENBQUMsUUFBUSxFQUFFLENBQUMsQ0FBQyxDQUFDO1FBQ2pDLElBQUksT0FBTyxHQUFHLE1BQU0sQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDdEMsSUFBSSxJQUFJLEdBQUcsYUFBYSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUMsQ0FBQztRQUNqQyxJQUFJLENBQUMsT0FBTyxDQUFDLFVBQVMsQ0FBQztZQUNyQixPQUFPLENBQUMsU0FBUyxHQUFHLFVBQVUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUM7WUFDeEMsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDakUsQ0FBQyxDQUFDLENBQUM7UUFDSCxFQUFFLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxVQUFVLENBQUMsQ0FBQyxLQUFLLENBQUMsU0FBUyxFQUFFLElBQUksQ0FBQyxDQUFDO0lBQ3RELENBQUM7SUFDRCxFQUFFLENBQUMsU0FBUyxDQUFDLFVBQVUsQ0FBQyxDQUFDLEtBQUssQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7SUFFbEQsRUFBRSxDQUFDLENBQUMsS0FBSyxDQUFDLE9BQU8sSUFBSSxlQUFPLENBQUMsY0FBYyxDQUFDLENBQUMsQ0FBQztRQUM1QyxHQUFHLENBQUMsQ0FBQyxJQUFJLE9BQU8sSUFBSSxnQkFBUSxDQUFDLENBQUMsQ0FBQztZQUM3QixJQUFJLE1BQU0sR0FDTixRQUFRLENBQUMsYUFBYSxDQUFDLHlCQUF1QixPQUFPLE1BQUcsQ0FBQyxDQUFDO1lBQzlELElBQUksYUFBYSxHQUFHLGdCQUFRLENBQUMsT0FBTyxDQUFDLENBQUM7WUFDdEMsZUFBZSxDQUFDLE1BQU0sRUFBRSxhQUFhLENBQUMsQ0FBQztRQUN6QyxDQUFDO0lBQ0gsQ0FBQztJQUNELEVBQUUsQ0FBQyxDQUFDLEtBQUssQ0FBQyxPQUFPLElBQUksZUFBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUM7UUFDeEMsR0FBRyxDQUFDLENBQUMsSUFBSSxVQUFVLElBQUksbUJBQVcsQ0FBQyxDQUFDLENBQUM7WUFDbkMsSUFBSSxNQUFNLEdBQ04sUUFBUSxDQUFDLGFBQWEsQ0FBQyw0QkFBMEIsVUFBVSxNQUFHLENBQUMsQ0FBQztZQUNwRSxJQUFJLGFBQWEsR0FBRyxtQkFBVyxDQUFDLFVBQVUsQ0FBQyxDQUFDO1lBQzVDLGVBQWUsQ0FBQyxNQUFNLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDekMsQ0FBQztJQUNILENBQUM7QUFDSCxDQUFDO0FBRUQ7SUFFRSxJQUFJLFdBQVcsR0FBRyxLQUFLLENBQUMsY0FBYyxFQUFFLENBQUM7SUFDekMsV0FBVyxDQUFDLE9BQU8sQ0FBQyxVQUFBLElBQUk7UUFDdEIsSUFBSSxRQUFRLEdBQUcsRUFBRSxDQUFDLFNBQVMsQ0FBQyxTQUFPLElBQU0sQ0FBQyxDQUFDO1FBQzNDLEVBQUUsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLEVBQUUsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3pCLE9BQU8sQ0FBQyxJQUFJLENBQUMsMENBQXdDLElBQU0sQ0FBQyxDQUFDO1FBQy9ELENBQUM7UUFDRCxRQUFRLENBQUMsS0FBSyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUNwQyxDQUFDLENBQUMsQ0FBQztJQUlILElBQUksWUFBWSxHQUFHLEVBQUUsQ0FBQyxNQUFNLENBQUMsZ0JBQWdCLENBQUMsQ0FBQztJQUMvQyxnQkFBZ0IsQ0FBQyxPQUFPLENBQUMsVUFBQyxFQUFVO1lBQVQsWUFBSSxFQUFFLFVBQUU7UUFDakMsSUFBSSxLQUFLLEdBQUcsWUFBWSxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUM7YUFDckMsSUFBSSxDQUFDLE9BQU8sRUFBRSxtREFBbUQsQ0FBQyxDQUFDO1FBQ3RFLElBQUksS0FBSyxHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDO2FBQzlCLElBQUksQ0FBQztZQUNKLElBQUksRUFBRSxVQUFVO1lBQ2hCLEtBQUssRUFBRSxxQkFBcUI7U0FDN0IsQ0FBQyxDQUFDO1FBQ0wsRUFBRSxDQUFDLENBQUMsV0FBVyxDQUFDLE9BQU8sQ0FBQyxFQUFFLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFDbEMsS0FBSyxDQUFDLElBQUksQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7UUFDaEMsQ0FBQztRQUNELEtBQUssQ0FBQyxFQUFFLENBQUMsUUFBUSxFQUFFO1lBQ2pCLEtBQUssQ0FBQyxlQUFlLENBQUMsRUFBRSxFQUFFLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO1lBQ3pDLEtBQUssQ0FBQyxTQUFTLEVBQUUsQ0FBQztZQUNsQixFQUFFLENBQUMsTUFBTSxDQUFDLHFCQUFxQixDQUFDO2lCQUM3QixJQUFJLENBQUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDeEMsQ0FBQyxDQUFDLENBQUM7UUFDSCxLQUFLLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQzthQUNqQixJQUFJLENBQUMsT0FBTyxFQUFFLDJCQUEyQixDQUFDO2FBQzFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNoQixDQUFDLENBQUMsQ0FBQztJQUNILEVBQUUsQ0FBQyxNQUFNLENBQUMscUJBQXFCLENBQUM7U0FDN0IsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ3hDLENBQUM7QUFFRCxzQkFBc0IsU0FBaUI7SUFBakIseUJBQWlCLEdBQWpCLGlCQUFpQjtJQUNyQyxFQUFFLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUM7UUFFZixLQUFLLENBQUMsSUFBSSxHQUFHLElBQUksQ0FBQyxNQUFNLEVBQUUsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDdEMsS0FBSyxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQ3BCLENBQUM7SUFDRCxJQUFJLENBQUMsVUFBVSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUM1QixJQUFJLFVBQVUsR0FBRyxDQUFDLEtBQUssQ0FBQyxPQUFPLElBQUksZUFBTyxDQUFDLFVBQVUsQ0FBQztRQUNsRCxtQkFBbUIsR0FBRyxvQkFBb0IsQ0FBQztJQUMvQyxJQUFJLFNBQVMsR0FBRyxLQUFLLENBQUMsT0FBTyxJQUFJLGVBQU8sQ0FBQyxjQUFjO1FBQ25ELEtBQUssQ0FBQyxPQUFPLEdBQUcsS0FBSyxDQUFDLFVBQVUsQ0FBQztJQUNyQyxJQUFJLElBQUksR0FBRyxTQUFTLENBQUMsVUFBVSxFQUFFLEtBQUssQ0FBQyxLQUFLLEdBQUcsR0FBRyxDQUFDLENBQUM7SUFFcEQsaUJBQU8sQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUVkLElBQUksVUFBVSxHQUFHLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLE1BQU0sR0FBRyxLQUFLLENBQUMsYUFBYSxHQUFHLEdBQUcsQ0FBQyxDQUFDO0lBQ3JFLFNBQVMsR0FBRyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxVQUFVLENBQUMsQ0FBQztJQUN0QyxRQUFRLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUNsQyxPQUFPLENBQUMsWUFBWSxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ2hDLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQyxLQUFLLENBQUMsWUFBWSxHQUFHLFFBQVEsR0FBRyxFQUFFLENBQUMsQ0FBQztBQUMvRCxDQUFDO0FBRUQscUJBQXFCLEVBQUUsQ0FBQztBQUN4QixZQUFZLEVBQUUsQ0FBQztBQUNmLE9BQU8sRUFBRSxDQUFDO0FBQ1YsWUFBWSxDQUFDLElBQUksQ0FBQyxDQUFDO0FBQ25CLEtBQUssRUFBRSxDQUFDO0FBQ1IsWUFBWSxFQUFFLENBQUM7Ozs7QUNoaUNmLElBQVksRUFBRSxXQUFNLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLElBQVksT0FBTyxXQUFNLFdBQVcsQ0FBQyxDQUFBO0FBR3JDLElBQU0saUJBQWlCLEdBQUcsT0FBTyxDQUFDO0FBR3ZCLG1CQUFXLEdBQTJDO0lBQy9ELFFBQVEsRUFBRSxFQUFFLENBQUMsV0FBVyxDQUFDLE1BQU07SUFDL0IsTUFBTSxFQUFFLEVBQUUsQ0FBQyxXQUFXLENBQUMsSUFBSTtJQUMzQixLQUFLLEVBQUUsRUFBRSxDQUFDLFdBQVcsQ0FBQyxHQUFHO0lBQ3pCLFVBQVUsRUFBRSxFQUFFLENBQUMsV0FBVyxDQUFDLFFBQVE7SUFDbkMsUUFBUSxFQUFFLEVBQUUsQ0FBQyxXQUFXLENBQUMsTUFBTTtJQUMvQixNQUFNLEVBQUUsRUFBRSxDQUFDLFdBQVcsQ0FBQyxJQUFJO0lBQzNCLFNBQVMsRUFBRSxFQUFFLENBQUMsV0FBVyxDQUFDLE9BQU87SUFDakMsS0FBSyxFQUFFLEVBQUUsQ0FBQyxXQUFXLENBQUMsUUFBUTtJQUM5QixVQUFVLEVBQUUsRUFBRSxDQUFDLFdBQVcsQ0FBQyxRQUFRO0lBQ25DLFVBQVUsRUFBRSxFQUFFLENBQUMsV0FBVyxDQUFDLFFBQVE7SUFDbkMsTUFBTSxFQUFFLEVBQUUsQ0FBQyxXQUFXLENBQUMsSUFBSTtDQUM1QixDQUFDO0FBR1MsdUJBQWUsR0FBK0M7SUFDdkUsTUFBTSxFQUFFLElBQUk7SUFDWixJQUFJLEVBQUUsRUFBRSxDQUFDLHNCQUFzQixDQUFDLEVBQUU7SUFDbEMsSUFBSSxFQUFFLEVBQUUsQ0FBQyxzQkFBc0IsQ0FBQyxFQUFFO0NBQ25DLENBQUM7QUFHUyxnQkFBUSxHQUEyQztJQUM1RCxRQUFRLEVBQUUsT0FBTyxDQUFDLGtCQUFrQjtJQUNwQyxLQUFLLEVBQUUsT0FBTyxDQUFDLGVBQWU7SUFDOUIsT0FBTyxFQUFFLE9BQU8sQ0FBQyxvQkFBb0I7SUFDckMsUUFBUSxFQUFFLE9BQU8sQ0FBQyxrQkFBa0I7Q0FDckMsQ0FBQztBQUdTLG1CQUFXLEdBQTJDO0lBQy9ELFdBQVcsRUFBRSxPQUFPLENBQUMsWUFBWTtJQUNqQyxXQUFXLEVBQUUsT0FBTyxDQUFDLGVBQWU7Q0FDckMsQ0FBQztBQUVGLHlCQUFnQyxHQUFRLEVBQUUsS0FBVTtJQUNsRCxHQUFHLENBQUMsQ0FBQyxJQUFJLEdBQUcsSUFBSSxHQUFHLENBQUMsQ0FBQyxDQUFDO1FBQ3BCLEVBQUUsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsS0FBSyxLQUFLLENBQUMsQ0FBQyxDQUFDO1lBQ3ZCLE1BQU0sQ0FBQyxHQUFHLENBQUM7UUFDYixDQUFDO0lBQ0gsQ0FBQztJQUNELE1BQU0sQ0FBQyxTQUFTLENBQUM7QUFDbkIsQ0FBQztBQVBlLHVCQUFlLGtCQU85QixDQUFBO0FBRUQsa0JBQWtCLENBQVMsRUFBRSxNQUFjO0lBQ3pDLE1BQU0sQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsTUFBTSxDQUFDLE1BQU0sQ0FBQyxLQUFLLE1BQU0sQ0FBQztBQUM3QyxDQUFDO0FBRUQsc0JBQXNCLEdBQVE7SUFDNUIsSUFBSSxNQUFNLEdBQWEsRUFBRSxDQUFDO0lBQzFCLEdBQUcsQ0FBQyxDQUFDLElBQUksSUFBSSxJQUFJLEdBQUcsQ0FBQyxDQUFDLENBQUM7UUFDckIsRUFBRSxDQUFDLENBQUMsUUFBUSxDQUFDLElBQUksRUFBRSxpQkFBaUIsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUN0QyxNQUFNLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQ3BCLENBQUM7SUFDSCxDQUFDO0lBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztBQUNoQixDQUFDO0FBTUQsV0FBWSxJQUFJO0lBQ2QsbUNBQU0sQ0FBQTtJQUNOLG1DQUFNLENBQUE7SUFDTiwrQ0FBWSxDQUFBO0lBQ1osK0NBQVksQ0FBQTtJQUNaLHFDQUFPLENBQUE7SUFDUCxtQ0FBTSxDQUFBO0FBQ1IsQ0FBQyxFQVBXLFlBQUksS0FBSixZQUFJLFFBT2Y7QUFQRCxJQUFZLElBQUksR0FBSixZQU9YLENBQUE7QUFFRCxXQUFZLE9BQU87SUFDakIseURBQWMsQ0FBQTtJQUNkLGlEQUFVLENBQUE7QUFDWixDQUFDLEVBSFcsZUFBTyxLQUFQLGVBQU8sUUFHbEI7QUFIRCxJQUFZLE9BQU8sR0FBUCxlQUdYLENBQUE7QUFFVSxnQkFBUSxHQUFHO0lBQ3BCLGdCQUFnQixFQUFFLE9BQU8sQ0FBQyxjQUFjO0lBQ3hDLFlBQVksRUFBRSxPQUFPLENBQUMsVUFBVTtDQUNqQyxDQUFDO0FBTUQsQ0FBQztBQUdGO0lBQUE7UUErQkUsaUJBQVksR0FBRyxJQUFJLENBQUM7UUFDcEIsdUJBQWtCLEdBQUcsQ0FBQyxDQUFDO1FBQ3ZCLGlCQUFZLEdBQUcsS0FBSyxDQUFDO1FBQ3JCLFVBQUssR0FBRyxDQUFDLENBQUM7UUFDVixjQUFTLEdBQUcsRUFBRSxDQUFDO1FBQ2YsZUFBVSxHQUFHLEtBQUssQ0FBQztRQUNuQixhQUFRLEdBQVcsSUFBSSxDQUFDO1FBQ3hCLGtCQUFhLEdBQUcsRUFBRSxDQUFDO1FBQ25CLGVBQVUsR0FBRyxFQUFFLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQztRQUNqQyxtQkFBYyxHQUE4QixJQUFJLENBQUM7UUFDakQsWUFBTyxHQUFHLE9BQU8sQ0FBQyxjQUFjLENBQUM7UUFDakMsaUJBQVksR0FBRyxLQUFLLENBQUM7UUFDckIsb0JBQWUsR0FBRyxDQUFDLENBQUM7UUFDcEIsd0JBQW1CLEdBQVUsRUFBRSxDQUFDO1FBQ2hDLGlCQUFZLEdBQWEsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7UUFDaEMsTUFBQyxHQUFHLElBQUksQ0FBQztRQUNULE1BQUMsR0FBRyxJQUFJLENBQUM7UUFDVCxZQUFPLEdBQUcsS0FBSyxDQUFDO1FBQ2hCLGFBQVEsR0FBRyxLQUFLLENBQUM7UUFDakIsYUFBUSxHQUFHLEtBQUssQ0FBQztRQUNqQixTQUFJLEdBQUcsS0FBSyxDQUFDO1FBQ2IsU0FBSSxHQUFHLEtBQUssQ0FBQztRQUNiLFNBQUksR0FBRyxLQUFLLENBQUM7UUFDYixTQUFJLEdBQUcsS0FBSyxDQUFDO1FBQ2IsWUFBTyxHQUEwQixPQUFPLENBQUMsa0JBQWtCLENBQUM7UUFDNUQsZUFBVSxHQUEwQixPQUFPLENBQUMsWUFBWSxDQUFDO0lBc0gzRCxDQUFDO0lBaEhRLHNCQUFnQixHQUF2QjtRQUNFLElBQUksR0FBRyxHQUE0QixFQUFFLENBQUM7UUFDdEMsR0FBRyxDQUFDLENBQWlCLFVBQXdDLEVBQXhDLEtBQUEsTUFBTSxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsRUFBeEMsY0FBd0MsRUFBeEMsSUFBd0MsQ0FBQztZQUF6RCxJQUFJLFFBQVEsU0FBQTtZQUNmLElBQUEsd0JBQXVDLEVBQWxDLGNBQUksRUFBRSxhQUFLLENBQXdCO1lBQ3hDLEdBQUcsQ0FBQyxNQUFJLENBQUMsR0FBRyxLQUFLLENBQUM7U0FDbkI7UUFDRCxJQUFJLEtBQUssR0FBRyxJQUFJLEtBQUssRUFBRSxDQUFDO1FBRXhCLGdCQUFnQixJQUFZO1lBQzFCLE1BQU0sQ0FBQyxJQUFJLElBQUksR0FBRyxJQUFJLEdBQUcsQ0FBQyxJQUFJLENBQUMsSUFBSSxJQUFJLElBQUksR0FBRyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxLQUFLLEVBQUUsQ0FBQztRQUNyRSxDQUFDO1FBRUQsb0JBQW9CLEtBQWE7WUFDL0IsTUFBTSxDQUFDLEtBQUssQ0FBQyxJQUFJLEVBQUUsS0FBSyxFQUFFLEdBQUcsRUFBRSxHQUFHLEtBQUssQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7UUFDckQsQ0FBQztRQUdELEtBQUssQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFVBQUMsRUFBb0I7Z0JBQW5CLGNBQUksRUFBRSxjQUFJLEVBQUUsa0JBQU07WUFDdEMsTUFBTSxDQUFDLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQztnQkFDYixLQUFLLElBQUksQ0FBQyxNQUFNO29CQUNkLEVBQUUsQ0FBQyxDQUFDLE1BQU0sSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDO3dCQUNuQixNQUFNLEtBQUssQ0FBQyw2Q0FBNkM7NEJBQ3JELDBCQUEwQixDQUFDLENBQUM7b0JBQ2xDLENBQUM7b0JBQ0QsRUFBRSxDQUFDLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxJQUFJLEdBQUcsQ0FBQyxJQUFJLENBQUMsSUFBSSxNQUFNLENBQUMsQ0FBQyxDQUFDO3dCQUN4QyxLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsTUFBTSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO29CQUNsQyxDQUFDO29CQUNELEtBQUssQ0FBQztnQkFDUixLQUFLLElBQUksQ0FBQyxNQUFNO29CQUNkLEVBQUUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUM7d0JBRWpCLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsQ0FBQztvQkFDM0IsQ0FBQztvQkFDRCxLQUFLLENBQUM7Z0JBQ1IsS0FBSyxJQUFJLENBQUMsTUFBTTtvQkFDZCxFQUFFLENBQUMsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO3dCQUNqQixLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsR0FBRyxDQUFDLElBQUksQ0FBQyxDQUFDO29CQUMxQixDQUFDO29CQUNELEtBQUssQ0FBQztnQkFDUixLQUFLLElBQUksQ0FBQyxPQUFPO29CQUNmLEVBQUUsQ0FBQyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUM7d0JBQ2pCLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxPQUFPLEdBQUcsS0FBSyxHQUFHLElBQUksQ0FBQyxDQUFDO29CQUN2RCxDQUFDO29CQUNELEtBQUssQ0FBQztnQkFDUixLQUFLLElBQUksQ0FBQyxZQUFZO29CQUNwQixFQUFFLENBQUMsQ0FBQyxJQUFJLElBQUksR0FBRyxDQUFDLENBQUMsQ0FBQzt3QkFDaEIsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFHLFVBQVUsQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUM7b0JBQ2xELENBQUM7b0JBQ0QsS0FBSyxDQUFDO2dCQUNSLEtBQUssSUFBSSxDQUFDLFlBQVk7b0JBQ3BCLEVBQUUsQ0FBQyxDQUFDLElBQUksSUFBSSxHQUFHLENBQUMsQ0FBQyxDQUFDO3dCQUNoQixLQUFLLENBQUMsSUFBSSxDQUFDLEdBQUcsVUFBVSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDO29CQUN0QyxDQUFDO29CQUNELEtBQUssQ0FBQztnQkFDUjtvQkFDRSxNQUFNLEtBQUssQ0FBQyxrREFBa0QsQ0FBQyxDQUFDO1lBQ3BFLENBQUM7UUFDSCxDQUFDLENBQUMsQ0FBQztRQUdILFlBQVksQ0FBQyxHQUFHLENBQUMsQ0FBQyxPQUFPLENBQUMsVUFBQSxJQUFJO1lBQzVCLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxNQUFNLENBQUMsR0FBRyxJQUFJLEdBQUcsS0FBSyxDQUFDO1FBQ3RELENBQUMsQ0FBQyxDQUFDO1FBQ0gsS0FBSyxDQUFDLGVBQWUsR0FBRyxLQUFLLENBQUMsWUFBWSxDQUFDLE1BQU0sQ0FBQztRQUNsRCxFQUFFLENBQUMsQ0FBQyxLQUFLLENBQUMsSUFBSSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUM7WUFDdkIsS0FBSyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsTUFBTSxFQUFFLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQ3hDLENBQUM7UUFDRCxJQUFJLENBQUMsVUFBVSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQztRQUM1QixNQUFNLENBQUMsS0FBSyxDQUFDO0lBQ2YsQ0FBQztJQUtELHlCQUFTLEdBQVQ7UUFBQSxpQkFzQkM7UUFwQkMsSUFBSSxLQUFLLEdBQWEsRUFBRSxDQUFDO1FBQ3pCLEtBQUssQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLFVBQUMsRUFBb0I7Z0JBQW5CLGNBQUksRUFBRSxjQUFJLEVBQUUsa0JBQU07WUFDdEMsSUFBSSxLQUFLLEdBQUcsS0FBSSxDQUFDLElBQUksQ0FBQyxDQUFDO1lBRXZCLEVBQUUsQ0FBQyxDQUFDLEtBQUssSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDO2dCQUNsQixNQUFNLENBQUM7WUFDVCxDQUFDO1lBQ0QsRUFBRSxDQUFDLENBQUMsSUFBSSxLQUFLLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO2dCQUN6QixLQUFLLEdBQUcsZUFBZSxDQUFDLE1BQU0sRUFBRSxLQUFLLENBQUMsQ0FBQztZQUN6QyxDQUFDO1lBQUMsSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDLElBQUksS0FBSyxJQUFJLENBQUMsWUFBWTtnQkFDakMsSUFBSSxLQUFLLElBQUksQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDO2dCQUMvQixLQUFLLEdBQUcsS0FBSyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQztZQUMxQixDQUFDO1lBQ0QsS0FBSyxDQUFDLElBQUksQ0FBSSxJQUFJLFNBQUksS0FBTyxDQUFDLENBQUM7UUFDakMsQ0FBQyxDQUFDLENBQUM7UUFFSCxZQUFZLENBQUMsSUFBSSxDQUFDLENBQUMsT0FBTyxDQUFDLFVBQUEsSUFBSTtZQUM3QixLQUFLLENBQUMsSUFBSSxDQUFJLElBQUksU0FBSSxLQUFJLENBQUMsSUFBSSxDQUFHLENBQUMsQ0FBQztRQUN0QyxDQUFDLENBQUMsQ0FBQztRQUNILE1BQU0sQ0FBQyxRQUFRLENBQUMsSUFBSSxHQUFHLEtBQUssQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDekMsQ0FBQztJQUdELDhCQUFjLEdBQWQ7UUFDRSxJQUFJLE1BQU0sR0FBYSxFQUFFLENBQUM7UUFDMUIsR0FBRyxDQUFDLENBQUMsSUFBSSxJQUFJLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQztZQUN0QixFQUFFLENBQUMsQ0FBQyxRQUFRLENBQUMsSUFBSSxFQUFFLGlCQUFpQixDQUFDLElBQUksSUFBSSxDQUFDLElBQUksQ0FBQyxLQUFLLElBQUksQ0FBQyxDQUFDLENBQUM7Z0JBQzdELE1BQU0sQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxpQkFBaUIsRUFBRSxFQUFFLENBQUMsQ0FBQyxDQUFDO1lBQ25ELENBQUM7UUFDSCxDQUFDO1FBQ0QsTUFBTSxDQUFDLE1BQU0sQ0FBQztJQUNoQixDQUFDO0lBRUQsK0JBQWUsR0FBZixVQUFnQixJQUFZLEVBQUUsTUFBZTtRQUMzQyxJQUFJLENBQUMsSUFBSSxHQUFHLGlCQUFpQixDQUFDLEdBQUcsTUFBTSxDQUFDO0lBQzFDLENBQUM7SUEzS2MsV0FBSyxHQUFlO1FBQ2pDLEVBQUMsSUFBSSxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsbUJBQVcsRUFBQztRQUM1RCxFQUFDLElBQUksRUFBRSxnQkFBZ0IsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsdUJBQWUsRUFBQztRQUNwRSxFQUFDLElBQUksRUFBRSxXQUFXLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUM7UUFDdEMsRUFBQyxJQUFJLEVBQUUsU0FBUyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRSxnQkFBUSxFQUFDO1FBQ3RELEVBQUMsSUFBSSxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBRSxNQUFNLEVBQUUsbUJBQVcsRUFBQztRQUM1RCxFQUFDLElBQUksRUFBRSxjQUFjLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUM7UUFDekMsRUFBQyxJQUFJLEVBQUUsb0JBQW9CLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUM7UUFDL0MsRUFBQyxJQUFJLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsTUFBTSxFQUFDO1FBQ2xDLEVBQUMsSUFBSSxFQUFFLGNBQWMsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLFlBQVksRUFBQztRQUMvQyxFQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUM7UUFDakMsRUFBQyxJQUFJLEVBQUUsY0FBYyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxFQUFDO1FBQzFDLEVBQUMsSUFBSSxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE9BQU8sRUFBQztRQUN4QyxFQUFDLElBQUksRUFBRSxlQUFlLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUM7UUFDMUMsRUFBQyxJQUFJLEVBQUUsR0FBRyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxFQUFDO1FBQy9CLEVBQUMsSUFBSSxFQUFFLEdBQUcsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE9BQU8sRUFBQztRQUMvQixFQUFDLElBQUksRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxPQUFPLEVBQUM7UUFDckMsRUFBQyxJQUFJLEVBQUUsVUFBVSxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxFQUFDO1FBQ3RDLEVBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE9BQU8sRUFBQztRQUN0QyxFQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxPQUFPLEVBQUM7UUFDbEMsRUFBQyxJQUFJLEVBQUUsTUFBTSxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxFQUFDO1FBQ2xDLEVBQUMsSUFBSSxFQUFFLE1BQU0sRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE9BQU8sRUFBQztRQUNsQyxFQUFDLElBQUksRUFBRSxNQUFNLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxPQUFPLEVBQUM7UUFDbEMsRUFBQyxJQUFJLEVBQUUsY0FBYyxFQUFFLElBQUksRUFBRSxJQUFJLENBQUMsT0FBTyxFQUFDO1FBQzFDLEVBQUMsSUFBSSxFQUFFLFVBQVUsRUFBRSxJQUFJLEVBQUUsSUFBSSxDQUFDLE1BQU0sRUFBQztRQUNyQyxFQUFDLElBQUksRUFBRSxTQUFTLEVBQUUsSUFBSSxFQUFFLElBQUksQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLGdCQUFRLEVBQUM7S0FDdkQsQ0FBQztJQWtKSixZQUFDO0FBQUQsQ0E5S0EsQUE4S0MsSUFBQTtBQTlLWSxhQUFLLFFBOEtqQixDQUFBIiwiZmlsZSI6ImdlbmVyYXRlZC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyIoZnVuY3Rpb24gZSh0LG4scil7ZnVuY3Rpb24gcyhvLHUpe2lmKCFuW29dKXtpZighdFtvXSl7dmFyIGE9dHlwZW9mIHJlcXVpcmU9PVwiZnVuY3Rpb25cIiYmcmVxdWlyZTtpZighdSYmYSlyZXR1cm4gYShvLCEwKTtpZihpKXJldHVybiBpKG8sITApO3ZhciBmPW5ldyBFcnJvcihcIkNhbm5vdCBmaW5kIG1vZHVsZSAnXCIrbytcIidcIik7dGhyb3cgZi5jb2RlPVwiTU9EVUxFX05PVF9GT1VORFwiLGZ9dmFyIGw9bltvXT17ZXhwb3J0czp7fX07dFtvXVswXS5jYWxsKGwuZXhwb3J0cyxmdW5jdGlvbihlKXt2YXIgbj10W29dWzFdW2VdO3JldHVybiBzKG4/bjplKX0sbCxsLmV4cG9ydHMsZSx0LG4scil9cmV0dXJuIG5bb10uZXhwb3J0c312YXIgaT10eXBlb2YgcmVxdWlyZT09XCJmdW5jdGlvblwiJiZyZXF1aXJlO2Zvcih2YXIgbz0wO288ci5sZW5ndGg7bysrKXMocltvXSk7cmV0dXJuIHN9KSIsIi8qIENvcHlyaWdodCAyMDE2IEdvb2dsZSBJbmMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQuXG5cbkxpY2Vuc2VkIHVuZGVyIHRoZSBBcGFjaGUgTGljZW5zZSwgVmVyc2lvbiAyLjAgKHRoZSBcIkxpY2Vuc2VcIik7XG55b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuXG5Zb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXRcblxuICAgIGh0dHA6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMFxuXG5Vbmxlc3MgcmVxdWlyZWQgYnkgYXBwbGljYWJsZSBsYXcgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNvZnR3YXJlXG5kaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhbiBcIkFTIElTXCIgQkFTSVMsXG5XSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTlkgS0lORCwgZWl0aGVyIGV4cHJlc3Mgb3IgaW1wbGllZC5cblNlZSB0aGUgTGljZW5zZSBmb3IgdGhlIHNwZWNpZmljIGxhbmd1YWdlIGdvdmVybmluZyBwZXJtaXNzaW9ucyBhbmRcbmxpbWl0YXRpb25zIHVuZGVyIHRoZSBMaWNlbnNlLlxuPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09Ki9cblxuLyoqXG4gKiBBIHR3byBkaW1lbnNpb25hbCBleGFtcGxlOiB4IGFuZCB5IGNvb3JkaW5hdGVzIHdpdGggdGhlIGxhYmVsLlxuICovXG5leHBvcnQgdHlwZSBFeGFtcGxlMkQgPSB7XG4gIHg6IG51bWJlcixcbiAgeTogbnVtYmVyLFxuICBsYWJlbDogbnVtYmVyXG59O1xuXG50eXBlIFBvaW50ID0ge1xuICB4OiBudW1iZXIsXG4gIHk6IG51bWJlclxufTtcblxuLyoqXG4gKiBTaHVmZmxlcyB0aGUgYXJyYXkgdXNpbmcgRmlzaGVyLVlhdGVzIGFsZ29yaXRobS4gVXNlcyB0aGUgc2VlZHJhbmRvbVxuICogbGlicmFyeSBhcyB0aGUgcmFuZG9tIGdlbmVyYXRvci5cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIHNodWZmbGUoYXJyYXk6IGFueVtdKTogdm9pZCB7XG4gIGxldCBjb3VudGVyID0gYXJyYXkubGVuZ3RoO1xuICBsZXQgdGVtcCA9IDA7XG4gIGxldCBpbmRleCA9IDA7XG4gIC8vIFdoaWxlIHRoZXJlIGFyZSBlbGVtZW50cyBpbiB0aGUgYXJyYXlcbiAgd2hpbGUgKGNvdW50ZXIgPiAwKSB7XG4gICAgLy8gUGljayBhIHJhbmRvbSBpbmRleFxuICAgIGluZGV4ID0gTWF0aC5mbG9vcihNYXRoLnJhbmRvbSgpICogY291bnRlcik7XG4gICAgLy8gRGVjcmVhc2UgY291bnRlciBieSAxXG4gICAgY291bnRlci0tO1xuICAgIC8vIEFuZCBzd2FwIHRoZSBsYXN0IGVsZW1lbnQgd2l0aCBpdFxuICAgIHRlbXAgPSBhcnJheVtjb3VudGVyXTtcbiAgICBhcnJheVtjb3VudGVyXSA9IGFycmF5W2luZGV4XTtcbiAgICBhcnJheVtpbmRleF0gPSB0ZW1wO1xuICB9XG59XG5cbmV4cG9ydCB0eXBlIERhdGFHZW5lcmF0b3IgPSAobnVtU2FtcGxlczogbnVtYmVyLCBub2lzZTogbnVtYmVyKSA9PiBFeGFtcGxlMkRbXTtcblxuZXhwb3J0IGZ1bmN0aW9uIGNsYXNzaWZ5VHdvR2F1c3NEYXRhKG51bVNhbXBsZXM6IG51bWJlciwgbm9pc2U6IG51bWJlcik6XG4gICAgRXhhbXBsZTJEW10ge1xuICBsZXQgcG9pbnRzOiBFeGFtcGxlMkRbXSA9IFtdO1xuXG4gIGxldCB2YXJpYW5jZVNjYWxlID0gZDMuc2NhbGUubGluZWFyKCkuZG9tYWluKFswLCAuNV0pLnJhbmdlKFswLjUsIDRdKTtcbiAgbGV0IHZhcmlhbmNlID0gdmFyaWFuY2VTY2FsZShub2lzZSk7XG5cbiAgZnVuY3Rpb24gZ2VuR2F1c3MoY3g6IG51bWJlciwgY3k6IG51bWJlciwgbGFiZWw6IG51bWJlcikge1xuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgbnVtU2FtcGxlcyAvIDI7IGkrKykge1xuICAgICAgbGV0IHggPSBub3JtYWxSYW5kb20oY3gsIHZhcmlhbmNlKTtcbiAgICAgIGxldCB5ID0gbm9ybWFsUmFuZG9tKGN5LCB2YXJpYW5jZSk7XG4gICAgICBwb2ludHMucHVzaCh7eDogeCwgeTogeSwgbGFiZWw6IGxhYmVsfSk7XG4gICAgfVxuICB9XG5cbiAgZ2VuR2F1c3MoMiwgMiwgMSk7IC8vIEdhdXNzaWFuIHdpdGggcG9zaXRpdmUgZXhhbXBsZXMuXG4gIGdlbkdhdXNzKC0yLCAtMiwgLTEpOyAvLyBHYXVzc2lhbiB3aXRoIG5lZ2F0aXZlIGV4YW1wbGVzLlxuICByZXR1cm4gcG9pbnRzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gcmVncmVzc1BsYW5lKG51bVNhbXBsZXM6IG51bWJlciwgbm9pc2U6IG51bWJlcik6XG4gIEV4YW1wbGUyRFtdIHtcbiAgbGV0IHJhZGl1cyA9IDY7XG4gIGxldCBsYWJlbFNjYWxlID0gZDMuc2NhbGUubGluZWFyKClcbiAgICAuZG9tYWluKFstMTAsIDEwXSlcbiAgICAucmFuZ2UoWy0xLCAxXSk7XG4gIGxldCBnZXRMYWJlbCA9ICh4LCB5KSA9PiBsYWJlbFNjYWxlKHggKyB5KTtcblxuICBsZXQgcG9pbnRzOiBFeGFtcGxlMkRbXSA9IFtdO1xuICBmb3IgKGxldCBpID0gMDsgaSA8IG51bVNhbXBsZXM7IGkrKykge1xuICAgIGxldCB4ID0gcmFuZFVuaWZvcm0oLXJhZGl1cywgcmFkaXVzKTtcbiAgICBsZXQgeSA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cyk7XG4gICAgbGV0IG5vaXNlWCA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cykgKiBub2lzZTtcbiAgICBsZXQgbm9pc2VZID0gcmFuZFVuaWZvcm0oLXJhZGl1cywgcmFkaXVzKSAqIG5vaXNlO1xuICAgIGxldCBsYWJlbCA9IGdldExhYmVsKHggKyBub2lzZVgsIHkgKyBub2lzZVkpO1xuICAgIHBvaW50cy5wdXNoKHt4OiB4LCB5OiB5LCBsYWJlbDogbGFiZWx9KTtcbiAgfVxuICByZXR1cm4gcG9pbnRzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gcmVncmVzc0dhdXNzaWFuKG51bVNhbXBsZXM6IG51bWJlciwgbm9pc2U6IG51bWJlcik6XG4gIEV4YW1wbGUyRFtdIHtcbiAgbGV0IHBvaW50czogRXhhbXBsZTJEW10gPSBbXTtcblxuICBsZXQgbGFiZWxTY2FsZSA9IGQzLnNjYWxlLmxpbmVhcigpXG4gICAgLmRvbWFpbihbMCwgMl0pXG4gICAgLnJhbmdlKFsxLCAwXSlcbiAgICAuY2xhbXAodHJ1ZSk7XG5cbiAgbGV0IGdhdXNzaWFucyA9IFtcbiAgICBbLTQsIDIuNSwgMV0sXG4gICAgWzAsIDIuNSwgLTFdLFxuICAgIFs0LCAyLjUsIDFdLFxuICAgIFstNCwgLTIuNSwgLTFdLFxuICAgIFswLCAtMi41LCAxXSxcbiAgICBbNCwgLTIuNSwgLTFdXG4gIF07XG5cbiAgZnVuY3Rpb24gZ2V0TGFiZWwoeCwgeSkge1xuICAgIC8vIENob29zZSB0aGUgb25lIHRoYXQgaXMgbWF4aW11bSBpbiBhYnMgdmFsdWUuXG4gICAgbGV0IGxhYmVsID0gMDtcbiAgICBnYXVzc2lhbnMuZm9yRWFjaCgoW2N4LCBjeSwgc2lnbl0pID0+IHtcbiAgICAgIGxldCBuZXdMYWJlbCA9IHNpZ24gKiBsYWJlbFNjYWxlKGRpc3Qoe3g6IHgsIHk6IHl9LCB7eDogY3gsIHk6IGN5fSkpO1xuICAgICAgaWYgKE1hdGguYWJzKG5ld0xhYmVsKSA+IE1hdGguYWJzKGxhYmVsKSkge1xuICAgICAgICBsYWJlbCA9IG5ld0xhYmVsO1xuICAgICAgfVxuICAgIH0pO1xuICAgIHJldHVybiBsYWJlbDtcbiAgfVxuICBsZXQgcmFkaXVzID0gNjtcbiAgZm9yIChsZXQgaSA9IDA7IGkgPCBudW1TYW1wbGVzOyBpKyspIHtcbiAgICBsZXQgeCA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cyk7XG4gICAgbGV0IHkgPSByYW5kVW5pZm9ybSgtcmFkaXVzLCByYWRpdXMpO1xuICAgIGxldCBub2lzZVggPSByYW5kVW5pZm9ybSgtcmFkaXVzLCByYWRpdXMpICogbm9pc2U7XG4gICAgbGV0IG5vaXNlWSA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cykgKiBub2lzZTtcbiAgICBsZXQgbGFiZWwgPSBnZXRMYWJlbCh4ICsgbm9pc2VYLCB5ICsgbm9pc2VZKTtcbiAgICBwb2ludHMucHVzaCh7eDogeCwgeTogeSwgbGFiZWw6IGxhYmVsfSk7XG4gIH07XG4gIHJldHVybiBwb2ludHM7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBjbGFzc2lmeVNwaXJhbERhdGEobnVtU2FtcGxlczogbnVtYmVyLCBub2lzZTogbnVtYmVyKTpcbiAgICBFeGFtcGxlMkRbXSB7XG4gIGxldCBwb2ludHM6IEV4YW1wbGUyRFtdID0gW107XG4gIGxldCBuID0gbnVtU2FtcGxlcyAvIDI7XG5cbiAgZnVuY3Rpb24gZ2VuU3BpcmFsKGRlbHRhVDogbnVtYmVyLCBsYWJlbDogbnVtYmVyKSB7XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBuOyBpKyspIHtcbiAgICAgIGxldCByID0gaSAvIG4gKiA1O1xuICAgICAgbGV0IHQgPSAxLjc1ICogaSAvIG4gKiAyICogTWF0aC5QSSArIGRlbHRhVDtcbiAgICAgIGxldCB4ID0gciAqIE1hdGguc2luKHQpICsgcmFuZFVuaWZvcm0oLTEsIDEpICogbm9pc2U7XG4gICAgICBsZXQgeSA9IHIgKiBNYXRoLmNvcyh0KSArIHJhbmRVbmlmb3JtKC0xLCAxKSAqIG5vaXNlO1xuICAgICAgcG9pbnRzLnB1c2goe3g6IHgsIHk6IHksIGxhYmVsOiBsYWJlbH0pO1xuICAgIH1cbiAgfVxuXG4gIGdlblNwaXJhbCgwLCAxKTsgLy8gUG9zaXRpdmUgZXhhbXBsZXMuXG4gIGdlblNwaXJhbChNYXRoLlBJLCAtMSk7IC8vIE5lZ2F0aXZlIGV4YW1wbGVzLlxuICByZXR1cm4gcG9pbnRzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gY2xhc3NpZnlDaXJjbGVEYXRhKG51bVNhbXBsZXM6IG51bWJlciwgbm9pc2U6IG51bWJlcik6XG4gICAgRXhhbXBsZTJEW10ge1xuICBsZXQgcG9pbnRzOiBFeGFtcGxlMkRbXSA9IFtdO1xuICBsZXQgcmFkaXVzID0gNTtcbiAgZnVuY3Rpb24gZ2V0Q2lyY2xlTGFiZWwocDogUG9pbnQsIGNlbnRlcjogUG9pbnQpIHtcbiAgICByZXR1cm4gKGRpc3QocCwgY2VudGVyKSA8IChyYWRpdXMgKiAwLjUpKSA/IDEgOiAtMTtcbiAgfVxuXG4gIC8vIEdlbmVyYXRlIHBvc2l0aXZlIHBvaW50cyBpbnNpZGUgdGhlIGNpcmNsZS5cbiAgZm9yIChsZXQgaSA9IDA7IGkgPCBudW1TYW1wbGVzIC8gMjsgaSsrKSB7XG4gICAgbGV0IHIgPSByYW5kVW5pZm9ybSgwLCByYWRpdXMgKiAwLjUpO1xuICAgIGxldCBhbmdsZSA9IHJhbmRVbmlmb3JtKDAsIDIgKiBNYXRoLlBJKTtcbiAgICBsZXQgeCA9IHIgKiBNYXRoLnNpbihhbmdsZSk7XG4gICAgbGV0IHkgPSByICogTWF0aC5jb3MoYW5nbGUpO1xuICAgIGxldCBub2lzZVggPSByYW5kVW5pZm9ybSgtcmFkaXVzLCByYWRpdXMpICogbm9pc2U7XG4gICAgbGV0IG5vaXNlWSA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cykgKiBub2lzZTtcbiAgICBsZXQgbGFiZWwgPSBnZXRDaXJjbGVMYWJlbCh7eDogeCArIG5vaXNlWCwgeTogeSArIG5vaXNlWX0sIHt4OiAwLCB5OiAwfSk7XG4gICAgcG9pbnRzLnB1c2goe3g6IHgsIHk6IHksIGxhYmVsOiBsYWJlbH0pO1xuICB9XG5cbiAgLy8gR2VuZXJhdGUgbmVnYXRpdmUgcG9pbnRzIG91dHNpZGUgdGhlIGNpcmNsZS5cbiAgZm9yIChsZXQgaSA9IDA7IGkgPCBudW1TYW1wbGVzIC8gMjsgaSsrKSB7XG4gICAgbGV0IHIgPSByYW5kVW5pZm9ybShyYWRpdXMgKiAwLjcsIHJhZGl1cyk7XG4gICAgbGV0IGFuZ2xlID0gcmFuZFVuaWZvcm0oMCwgMiAqIE1hdGguUEkpO1xuICAgIGxldCB4ID0gciAqIE1hdGguc2luKGFuZ2xlKTtcbiAgICBsZXQgeSA9IHIgKiBNYXRoLmNvcyhhbmdsZSk7XG4gICAgbGV0IG5vaXNlWCA9IHJhbmRVbmlmb3JtKC1yYWRpdXMsIHJhZGl1cykgKiBub2lzZTtcbiAgICBsZXQgbm9pc2VZID0gcmFuZFVuaWZvcm0oLXJhZGl1cywgcmFkaXVzKSAqIG5vaXNlO1xuICAgIGxldCBsYWJlbCA9IGdldENpcmNsZUxhYmVsKHt4OiB4ICsgbm9pc2VYLCB5OiB5ICsgbm9pc2VZfSwge3g6IDAsIHk6IDB9KTtcbiAgICBwb2ludHMucHVzaCh7eDogeCwgeTogeSwgbGFiZWw6IGxhYmVsfSk7XG4gIH1cbiAgcmV0dXJuIHBvaW50cztcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGNsYXNzaWZ5WE9SRGF0YShudW1TYW1wbGVzOiBudW1iZXIsIG5vaXNlOiBudW1iZXIpOlxuICAgIEV4YW1wbGUyRFtdIHtcbiAgZnVuY3Rpb24gZ2V0WE9STGFiZWwocDogUG9pbnQpIHsgcmV0dXJuIHAueCAqIHAueSA+PSAwID8gMSA6IC0xOyB9XG5cbiAgbGV0IHBvaW50czogRXhhbXBsZTJEW10gPSBbXTtcbiAgZm9yIChsZXQgaSA9IDA7IGkgPCBudW1TYW1wbGVzOyBpKyspIHtcbiAgICBsZXQgeCA9IHJhbmRVbmlmb3JtKC01LCA1KTtcbiAgICBsZXQgcGFkZGluZyA9IDAuMztcbiAgICB4ICs9IHggPiAwID8gcGFkZGluZyA6IC1wYWRkaW5nOyAgLy8gUGFkZGluZy5cbiAgICBsZXQgeSA9IHJhbmRVbmlmb3JtKC01LCA1KTtcbiAgICB5ICs9IHkgPiAwID8gcGFkZGluZyA6IC1wYWRkaW5nO1xuICAgIGxldCBub2lzZVggPSByYW5kVW5pZm9ybSgtNSwgNSkgKiBub2lzZTtcbiAgICBsZXQgbm9pc2VZID0gcmFuZFVuaWZvcm0oLTUsIDUpICogbm9pc2U7XG4gICAgbGV0IGxhYmVsID0gZ2V0WE9STGFiZWwoe3g6IHggKyBub2lzZVgsIHk6IHkgKyBub2lzZVl9KTtcbiAgICBwb2ludHMucHVzaCh7eDogeCwgeTogeSwgbGFiZWw6IGxhYmVsfSk7XG4gIH1cbiAgcmV0dXJuIHBvaW50cztcbn1cblxuLyoqXG4gKiBSZXR1cm5zIGEgc2FtcGxlIGZyb20gYSB1bmlmb3JtIFthLCBiXSBkaXN0cmlidXRpb24uXG4gKiBVc2VzIHRoZSBzZWVkcmFuZG9tIGxpYnJhcnkgYXMgdGhlIHJhbmRvbSBnZW5lcmF0b3IuXG4gKi9cbmZ1bmN0aW9uIHJhbmRVbmlmb3JtKGE6IG51bWJlciwgYjogbnVtYmVyKSB7XG4gIHJldHVybiBNYXRoLnJhbmRvbSgpICogKGIgLSBhKSArIGE7XG59XG5cbi8qKlxuICogU2FtcGxlcyBmcm9tIGEgbm9ybWFsIGRpc3RyaWJ1dGlvbi4gVXNlcyB0aGUgc2VlZHJhbmRvbSBsaWJyYXJ5IGFzIHRoZVxuICogcmFuZG9tIGdlbmVyYXRvci5cbiAqXG4gKiBAcGFyYW0gbWVhbiBUaGUgbWVhbi4gRGVmYXVsdCBpcyAwLlxuICogQHBhcmFtIHZhcmlhbmNlIFRoZSB2YXJpYW5jZS4gRGVmYXVsdCBpcyAxLlxuICovXG5mdW5jdGlvbiBub3JtYWxSYW5kb20obWVhbiA9IDAsIHZhcmlhbmNlID0gMSk6IG51bWJlciB7XG4gIGxldCB2MTogbnVtYmVyLCB2MjogbnVtYmVyLCBzOiBudW1iZXI7XG4gIGRvIHtcbiAgICB2MSA9IDIgKiBNYXRoLnJhbmRvbSgpIC0gMTtcbiAgICB2MiA9IDIgKiBNYXRoLnJhbmRvbSgpIC0gMTtcbiAgICBzID0gdjEgKiB2MSArIHYyICogdjI7XG4gIH0gd2hpbGUgKHMgPiAxKTtcblxuICBsZXQgcmVzdWx0ID0gTWF0aC5zcXJ0KC0yICogTWF0aC5sb2cocykgLyBzKSAqIHYxO1xuICByZXR1cm4gbWVhbiArIE1hdGguc3FydCh2YXJpYW5jZSkgKiByZXN1bHQ7XG59XG5cbi8qKiBSZXR1cm5zIHRoZSBldWNsZWRpYW4gZGlzdGFuY2UgYmV0d2VlbiB0d28gcG9pbnRzIGluIHNwYWNlLiAqL1xuZnVuY3Rpb24gZGlzdChhOiBQb2ludCwgYjogUG9pbnQpOiBudW1iZXIge1xuICBsZXQgZHggPSBhLnggLSBiLng7XG4gIGxldCBkeSA9IGEueSAtIGIueTtcbiAgcmV0dXJuIE1hdGguc3FydChkeCAqIGR4ICsgZHkgKiBkeSk7XG59XG4iLCIvKiBDb3B5cmlnaHQgMjAxNiBHb29nbGUgSW5jLiBBbGwgUmlnaHRzIFJlc2VydmVkLlxuXG5MaWNlbnNlZCB1bmRlciB0aGUgQXBhY2hlIExpY2Vuc2UsIFZlcnNpb24gMi4wICh0aGUgXCJMaWNlbnNlXCIpO1xueW91IG1heSBub3QgdXNlIHRoaXMgZmlsZSBleGNlcHQgaW4gY29tcGxpYW5jZSB3aXRoIHRoZSBMaWNlbnNlLlxuWW91IG1heSBvYnRhaW4gYSBjb3B5IG9mIHRoZSBMaWNlbnNlIGF0XG5cbiAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvTElDRU5TRS0yLjBcblxuVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZVxuZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gXCJBUyBJU1wiIEJBU0lTLFxuV0lUSE9VVCBXQVJSQU5USUVTIE9SIENPTkRJVElPTlMgT0YgQU5ZIEtJTkQsIGVpdGhlciBleHByZXNzIG9yIGltcGxpZWQuXG5TZWUgdGhlIExpY2Vuc2UgZm9yIHRoZSBzcGVjaWZpYyBsYW5ndWFnZSBnb3Zlcm5pbmcgcGVybWlzc2lvbnMgYW5kXG5saW1pdGF0aW9ucyB1bmRlciB0aGUgTGljZW5zZS5cbj09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSovXG5cbmltcG9ydCB7RXhhbXBsZTJEfSBmcm9tIFwiLi9kYXRhc2V0XCI7XG5cbmV4cG9ydCBpbnRlcmZhY2UgSGVhdE1hcFNldHRpbmdzIHtcbiAgW2tleTogc3RyaW5nXTogYW55O1xuICBzaG93QXhlcz86IGJvb2xlYW47XG4gIG5vU3ZnPzogYm9vbGVhbjtcbn1cblxuLyoqIE51bWJlciBvZiBkaWZmZXJlbnQgc2hhZGVzIChjb2xvcnMpIHdoZW4gZHJhd2luZyBhIGdyYWRpZW50IGhlYXRtYXAgKi9cbmNvbnN0IE5VTV9TSEFERVMgPSAzMDtcblxuLyoqXG4gKiBEcmF3cyBhIGhlYXRtYXAgdXNpbmcgY2FudmFzLiBVc2VkIGZvciBzaG93aW5nIHRoZSBsZWFybmVkIGRlY2lzaW9uXG4gKiBib3VuZGFyeSBvZiB0aGUgY2xhc3NpZmljYXRpb24gYWxnb3JpdGhtLiBDYW4gYWxzbyBkcmF3IGRhdGEgcG9pbnRzXG4gKiB1c2luZyBhbiBzdmcgb3ZlcmxheWVkIG9uIHRvcCBvZiB0aGUgY2FudmFzIGhlYXRtYXAuXG4gKi9cbmV4cG9ydCBjbGFzcyBIZWF0TWFwIHtcbiAgcHJpdmF0ZSBzZXR0aW5nczogSGVhdE1hcFNldHRpbmdzID0ge1xuICAgIHNob3dBeGVzOiBmYWxzZSxcbiAgICBub1N2ZzogZmFsc2VcbiAgfTtcbiAgcHJpdmF0ZSB4U2NhbGU6IGQzLnNjYWxlLkxpbmVhcjxudW1iZXIsIG51bWJlcj47XG4gIHByaXZhdGUgeVNjYWxlOiBkMy5zY2FsZS5MaW5lYXI8bnVtYmVyLCBudW1iZXI+O1xuICBwcml2YXRlIG51bVNhbXBsZXM6IG51bWJlcjtcbiAgcHJpdmF0ZSBjb2xvcjogZDMuc2NhbGUuUXVhbnRpemU8c3RyaW5nPjtcbiAgcHJpdmF0ZSBjYW52YXM6IGQzLlNlbGVjdGlvbjxhbnk+O1xuICBwcml2YXRlIHN2ZzogZDMuU2VsZWN0aW9uPGFueT47XG5cbiAgY29uc3RydWN0b3IoXG4gICAgICB3aWR0aDogbnVtYmVyLCBudW1TYW1wbGVzOiBudW1iZXIsIHhEb21haW46IFtudW1iZXIsIG51bWJlcl0sXG4gICAgICB5RG9tYWluOiBbbnVtYmVyLCBudW1iZXJdLCBjb250YWluZXI6IGQzLlNlbGVjdGlvbjxhbnk+LFxuICAgICAgdXNlclNldHRpbmdzPzogSGVhdE1hcFNldHRpbmdzKSB7XG4gICAgdGhpcy5udW1TYW1wbGVzID0gbnVtU2FtcGxlcztcbiAgICBsZXQgaGVpZ2h0ID0gd2lkdGg7XG4gICAgbGV0IHBhZGRpbmcgPSB1c2VyU2V0dGluZ3Muc2hvd0F4ZXMgPyAyMCA6IDA7XG5cbiAgICBpZiAodXNlclNldHRpbmdzICE9IG51bGwpIHtcbiAgICAgIC8vIG92ZXJ3cml0ZSB0aGUgZGVmYXVsdHMgd2l0aCB0aGUgdXNlci1zcGVjaWZpZWQgc2V0dGluZ3MuXG4gICAgICBmb3IgKGxldCBwcm9wIGluIHVzZXJTZXR0aW5ncykge1xuICAgICAgICB0aGlzLnNldHRpbmdzW3Byb3BdID0gdXNlclNldHRpbmdzW3Byb3BdO1xuICAgICAgfVxuICAgIH1cblxuICAgIHRoaXMueFNjYWxlID0gZDMuc2NhbGUubGluZWFyKClcbiAgICAgIC5kb21haW4oeERvbWFpbilcbiAgICAgIC5yYW5nZShbMCwgd2lkdGggLSAyICogcGFkZGluZ10pO1xuXG4gICAgdGhpcy55U2NhbGUgPSBkMy5zY2FsZS5saW5lYXIoKVxuICAgICAgLmRvbWFpbih5RG9tYWluKVxuICAgICAgLnJhbmdlKFtoZWlnaHQgLSAyICogcGFkZGluZywgMF0pO1xuXG4gICAgLy8gR2V0IGEgcmFuZ2Ugb2YgY29sb3JzLlxuICAgIGxldCB0bXBTY2FsZSA9IGQzLnNjYWxlLmxpbmVhcjxzdHJpbmcsIHN0cmluZz4oKVxuICAgICAgICAuZG9tYWluKFswLCAuNSwgMV0pXG4gICAgICAgIC5yYW5nZShbXCIjZjU5MzIyXCIsIFwiI2U4ZWFlYlwiLCBcIiMwODc3YmRcIl0pXG4gICAgICAgIC5jbGFtcCh0cnVlKTtcbiAgICAvLyBEdWUgdG8gbnVtZXJpY2FsIGVycm9yLCB3ZSBuZWVkIHRvIHNwZWNpZnlcbiAgICAvLyBkMy5yYW5nZSgwLCBlbmQgKyBzbWFsbF9lcHNpbG9uLCBzdGVwKVxuICAgIC8vIGluIG9yZGVyIHRvIGd1YXJhbnRlZSB0aGF0IHdlIHdpbGwgaGF2ZSBlbmQvc3RlcCBlbnRyaWVzIHdpdGhcbiAgICAvLyB0aGUgbGFzdCBlbGVtZW50IGJlaW5nIGVxdWFsIHRvIGVuZC5cbiAgICBsZXQgY29sb3JzID0gZDMucmFuZ2UoMCwgMSArIDFFLTksIDEgLyBOVU1fU0hBREVTKS5tYXAoYSA9PiB7XG4gICAgICByZXR1cm4gdG1wU2NhbGUoYSk7XG4gICAgfSk7XG4gICAgdGhpcy5jb2xvciA9IGQzLnNjYWxlLnF1YW50aXplPHN0cmluZz4oKVxuICAgICAgICAgICAgICAgICAgICAgLmRvbWFpbihbLTEsIDFdKVxuICAgICAgICAgICAgICAgICAgICAgLnJhbmdlKGNvbG9ycyk7XG5cbiAgICBjb250YWluZXIgPSBjb250YWluZXIuYXBwZW5kKFwiZGl2XCIpXG4gICAgICAuc3R5bGUoe1xuICAgICAgICB3aWR0aDogYCR7d2lkdGh9cHhgLFxuICAgICAgICBoZWlnaHQ6IGAke2hlaWdodH1weGAsXG4gICAgICAgIHBvc2l0aW9uOiBcInJlbGF0aXZlXCIsXG4gICAgICAgIHRvcDogYC0ke3BhZGRpbmd9cHhgLFxuICAgICAgICBsZWZ0OiBgLSR7cGFkZGluZ31weGBcbiAgICAgIH0pO1xuICAgIHRoaXMuY2FudmFzID0gY29udGFpbmVyLmFwcGVuZChcImNhbnZhc1wiKVxuICAgICAgLmF0dHIoXCJ3aWR0aFwiLCBudW1TYW1wbGVzKVxuICAgICAgLmF0dHIoXCJoZWlnaHRcIiwgbnVtU2FtcGxlcylcbiAgICAgIC5zdHlsZShcIndpZHRoXCIsICh3aWR0aCAtIDIgKiBwYWRkaW5nKSArIFwicHhcIilcbiAgICAgIC5zdHlsZShcImhlaWdodFwiLCAoaGVpZ2h0IC0gMiAqIHBhZGRpbmcpICsgXCJweFwiKVxuICAgICAgLnN0eWxlKFwicG9zaXRpb25cIiwgXCJhYnNvbHV0ZVwiKVxuICAgICAgLnN0eWxlKFwidG9wXCIsIGAke3BhZGRpbmd9cHhgKVxuICAgICAgLnN0eWxlKFwibGVmdFwiLCBgJHtwYWRkaW5nfXB4YCk7XG5cbiAgICBpZiAoIXRoaXMuc2V0dGluZ3Mubm9TdmcpIHtcbiAgICAgIHRoaXMuc3ZnID0gY29udGFpbmVyLmFwcGVuZChcInN2Z1wiKS5hdHRyKHtcbiAgICAgICAgICBcIndpZHRoXCI6IHdpZHRoLFxuICAgICAgICAgIFwiaGVpZ2h0XCI6IGhlaWdodFxuICAgICAgfSkuc3R5bGUoe1xuICAgICAgICAvLyBPdmVybGF5IHRoZSBzdmcgb24gdG9wIG9mIHRoZSBjYW52YXMuXG4gICAgICAgIFwicG9zaXRpb25cIjogXCJhYnNvbHV0ZVwiLFxuICAgICAgICBcImxlZnRcIjogXCIwXCIsXG4gICAgICAgIFwidG9wXCI6IFwiMFwiXG4gICAgICB9KS5hcHBlbmQoXCJnXCIpXG4gICAgICAgIC5hdHRyKFwidHJhbnNmb3JtXCIsIGB0cmFuc2xhdGUoJHtwYWRkaW5nfSwke3BhZGRpbmd9KWApO1xuXG4gICAgICB0aGlzLnN2Zy5hcHBlbmQoXCJnXCIpLmF0dHIoXCJjbGFzc1wiLCBcInRyYWluXCIpO1xuICAgICAgdGhpcy5zdmcuYXBwZW5kKFwiZ1wiKS5hdHRyKFwiY2xhc3NcIiwgXCJ0ZXN0XCIpO1xuICAgIH1cblxuICAgIGlmICh0aGlzLnNldHRpbmdzLnNob3dBeGVzKSB7XG4gICAgICBsZXQgeEF4aXMgPSBkMy5zdmcuYXhpcygpXG4gICAgICAgIC5zY2FsZSh0aGlzLnhTY2FsZSlcbiAgICAgICAgLm9yaWVudChcImJvdHRvbVwiKTtcblxuICAgICAgbGV0IHlBeGlzID0gZDMuc3ZnLmF4aXMoKVxuICAgICAgICAuc2NhbGUodGhpcy55U2NhbGUpXG4gICAgICAgIC5vcmllbnQoXCJyaWdodFwiKTtcblxuICAgICAgdGhpcy5zdmcuYXBwZW5kKFwiZ1wiKVxuICAgICAgICAuYXR0cihcImNsYXNzXCIsIFwieCBheGlzXCIpXG4gICAgICAgIC5hdHRyKFwidHJhbnNmb3JtXCIsIGB0cmFuc2xhdGUoMCwke2hlaWdodCAtIDIgKiBwYWRkaW5nfSlgKVxuICAgICAgICAuY2FsbCh4QXhpcyk7XG5cbiAgICAgIHRoaXMuc3ZnLmFwcGVuZChcImdcIilcbiAgICAgICAgLmF0dHIoXCJjbGFzc1wiLCBcInkgYXhpc1wiKVxuICAgICAgICAuYXR0cihcInRyYW5zZm9ybVwiLCBcInRyYW5zbGF0ZShcIiArICh3aWR0aCAtIDIgKiBwYWRkaW5nKSArIFwiLDApXCIpXG4gICAgICAgIC5jYWxsKHlBeGlzKTtcbiAgICB9XG4gIH1cblxuICB1cGRhdGVUZXN0UG9pbnRzKHBvaW50czogRXhhbXBsZTJEW10pOiB2b2lkIHtcbiAgICBpZiAodGhpcy5zZXR0aW5ncy5ub1N2Zykge1xuICAgICAgdGhyb3cgRXJyb3IoXCJDYW4ndCBhZGQgcG9pbnRzIHNpbmNlIG5vU3ZnPXRydWVcIik7XG4gICAgfVxuICAgIHRoaXMudXBkYXRlQ2lyY2xlcyh0aGlzLnN2Zy5zZWxlY3QoXCJnLnRlc3RcIiksIHBvaW50cyk7XG4gIH1cblxuICB1cGRhdGVQb2ludHMocG9pbnRzOiBFeGFtcGxlMkRbXSk6IHZvaWQge1xuICAgIGlmICh0aGlzLnNldHRpbmdzLm5vU3ZnKSB7XG4gICAgICB0aHJvdyBFcnJvcihcIkNhbid0IGFkZCBwb2ludHMgc2luY2Ugbm9Tdmc9dHJ1ZVwiKTtcbiAgICB9XG4gICAgdGhpcy51cGRhdGVDaXJjbGVzKHRoaXMuc3ZnLnNlbGVjdChcImcudHJhaW5cIiksIHBvaW50cyk7XG4gIH1cblxuICB1cGRhdGVCYWNrZ3JvdW5kKGRhdGE6IG51bWJlcltdW10sIGRpc2NyZXRpemU6IGJvb2xlYW4pOiB2b2lkIHtcbiAgICBsZXQgZHggPSBkYXRhWzBdLmxlbmd0aDtcbiAgICBsZXQgZHkgPSBkYXRhLmxlbmd0aDtcblxuICAgIGlmIChkeCAhPT0gdGhpcy5udW1TYW1wbGVzIHx8IGR5ICE9PSB0aGlzLm51bVNhbXBsZXMpIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcihcbiAgICAgICAgICBcIlRoZSBwcm92aWRlZCBkYXRhIG1hdHJpeCBtdXN0IGJlIG9mIHNpemUgXCIgK1xuICAgICAgICAgIFwibnVtU2FtcGxlcyBYIG51bVNhbXBsZXNcIik7XG4gICAgfVxuXG4gICAgLy8gQ29tcHV0ZSB0aGUgcGl4ZWwgY29sb3JzOyBzY2FsZWQgYnkgQ1NTLlxuICAgIGxldCBjb250ZXh0ID0gKDxIVE1MQ2FudmFzRWxlbWVudD50aGlzLmNhbnZhcy5ub2RlKCkpLmdldENvbnRleHQoXCIyZFwiKTtcbiAgICBsZXQgaW1hZ2UgPSBjb250ZXh0LmNyZWF0ZUltYWdlRGF0YShkeCwgZHkpO1xuXG4gICAgZm9yIChsZXQgeSA9IDAsIHAgPSAtMTsgeSA8IGR5OyArK3kpIHtcbiAgICAgIGZvciAobGV0IHggPSAwOyB4IDwgZHg7ICsreCkge1xuICAgICAgICBsZXQgdmFsdWUgPSBkYXRhW3hdW3ldO1xuICAgICAgICBpZiAoZGlzY3JldGl6ZSkge1xuICAgICAgICAgIHZhbHVlID0gKHZhbHVlID49IDAgPyAxIDogLTEpO1xuICAgICAgICB9XG4gICAgICAgIGxldCBjID0gZDMucmdiKHRoaXMuY29sb3IodmFsdWUpKTtcbiAgICAgICAgaW1hZ2UuZGF0YVsrK3BdID0gYy5yO1xuICAgICAgICBpbWFnZS5kYXRhWysrcF0gPSBjLmc7XG4gICAgICAgIGltYWdlLmRhdGFbKytwXSA9IGMuYjtcbiAgICAgICAgaW1hZ2UuZGF0YVsrK3BdID0gMTYwO1xuICAgICAgfVxuICAgIH1cbiAgICBjb250ZXh0LnB1dEltYWdlRGF0YShpbWFnZSwgMCwgMCk7XG4gIH1cblxuICBwcml2YXRlIHVwZGF0ZUNpcmNsZXMoY29udGFpbmVyOiBkMy5TZWxlY3Rpb248YW55PiwgcG9pbnRzOiBFeGFtcGxlMkRbXSkge1xuICAgIC8vIEtlZXAgb25seSBwb2ludHMgdGhhdCBhcmUgaW5zaWRlIHRoZSBib3VuZHMuXG4gICAgbGV0IHhEb21haW4gPSB0aGlzLnhTY2FsZS5kb21haW4oKTtcbiAgICBsZXQgeURvbWFpbiA9IHRoaXMueVNjYWxlLmRvbWFpbigpO1xuICAgIHBvaW50cyA9IHBvaW50cy5maWx0ZXIocCA9PiB7XG4gICAgICByZXR1cm4gcC54ID49IHhEb21haW5bMF0gJiYgcC54IDw9IHhEb21haW5bMV1cbiAgICAgICAgJiYgcC55ID49IHlEb21haW5bMF0gJiYgcC55IDw9IHlEb21haW5bMV07XG4gICAgfSk7XG5cbiAgICAvLyBBdHRhY2ggZGF0YSB0byBpbml0aWFsbHkgZW1wdHkgc2VsZWN0aW9uLlxuICAgIGxldCBzZWxlY3Rpb24gPSBjb250YWluZXIuc2VsZWN0QWxsKFwiY2lyY2xlXCIpLmRhdGEocG9pbnRzKTtcblxuICAgIC8vIEluc2VydCBlbGVtZW50cyB0byBtYXRjaCBsZW5ndGggb2YgcG9pbnRzIGFycmF5LlxuICAgIHNlbGVjdGlvbi5lbnRlcigpLmFwcGVuZChcImNpcmNsZVwiKS5hdHRyKFwiclwiLCAzKTtcblxuICAgIC8vIFVwZGF0ZSBwb2ludHMgdG8gYmUgaW4gdGhlIGNvcnJlY3QgcG9zaXRpb24uXG4gICAgc2VsZWN0aW9uXG4gICAgICAuYXR0cih7XG4gICAgICAgIGN4OiAoZDogRXhhbXBsZTJEKSA9PiB0aGlzLnhTY2FsZShkLngpLFxuICAgICAgICBjeTogKGQ6IEV4YW1wbGUyRCkgPT4gdGhpcy55U2NhbGUoZC55KSxcbiAgICAgIH0pXG4gICAgICAuc3R5bGUoXCJmaWxsXCIsIGQgPT4gdGhpcy5jb2xvcihkLmxhYmVsKSk7XG5cbiAgICAvLyBSZW1vdmUgcG9pbnRzIGlmIHRoZSBsZW5ndGggaGFzIGdvbmUgZG93bi5cbiAgICBzZWxlY3Rpb24uZXhpdCgpLnJlbW92ZSgpO1xuICB9XG59ICAvLyBDbG9zZSBjbGFzcyBIZWF0TWFwLlxuXG5leHBvcnQgZnVuY3Rpb24gcmVkdWNlTWF0cml4KG1hdHJpeDogbnVtYmVyW11bXSwgZmFjdG9yOiBudW1iZXIpOiBudW1iZXJbXVtdIHtcbiAgaWYgKG1hdHJpeC5sZW5ndGggIT09IG1hdHJpeFswXS5sZW5ndGgpIHtcbiAgICB0aHJvdyBuZXcgRXJyb3IoXCJUaGUgcHJvdmlkZWQgbWF0cml4IG11c3QgYmUgYSBzcXVhcmUgbWF0cml4XCIpO1xuICB9XG4gIGlmIChtYXRyaXgubGVuZ3RoICUgZmFjdG9yICE9PSAwKSB7XG4gICAgdGhyb3cgbmV3IEVycm9yKFwiVGhlIHdpZHRoL2hlaWdodCBvZiB0aGUgbWF0cml4IG11c3QgYmUgZGl2aXNpYmxlIGJ5IFwiICtcbiAgICAgICAgXCJ0aGUgcmVkdWN0aW9uIGZhY3RvclwiKTtcbiAgfVxuICBsZXQgcmVzdWx0OiBudW1iZXJbXVtdID0gbmV3IEFycmF5KG1hdHJpeC5sZW5ndGggLyBmYWN0b3IpO1xuICBmb3IgKGxldCBpID0gMDsgaSA8IG1hdHJpeC5sZW5ndGg7IGkgKz0gZmFjdG9yKSB7XG4gICAgcmVzdWx0W2kgLyBmYWN0b3JdID0gbmV3IEFycmF5KG1hdHJpeC5sZW5ndGggLyBmYWN0b3IpO1xuICAgIGZvciAobGV0IGogPSAwOyBqIDwgbWF0cml4Lmxlbmd0aDsgaiArPSBmYWN0b3IpIHtcbiAgICAgIGxldCBhdmcgPSAwO1xuICAgICAgLy8gU3VtIGFsbCB0aGUgdmFsdWVzIGluIHRoZSBuZWlnaGJvcmhvb2QuXG4gICAgICBmb3IgKGxldCBrID0gMDsgayA8IGZhY3RvcjsgaysrKSB7XG4gICAgICAgIGZvciAobGV0IGwgPSAwOyBsIDwgZmFjdG9yOyBsKyspIHtcbiAgICAgICAgICBhdmcgKz0gbWF0cml4W2kgKyBrXVtqICsgbF07XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICAgIGF2ZyAvPSAoZmFjdG9yICogZmFjdG9yKTtcbiAgICAgIHJlc3VsdFtpIC8gZmFjdG9yXVtqIC8gZmFjdG9yXSA9IGF2ZztcbiAgICB9XG4gIH1cbiAgcmV0dXJuIHJlc3VsdDtcbn1cbiIsIi8qIENvcHlyaWdodCAyMDE2IEdvb2dsZSBJbmMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQuXG5cbkxpY2Vuc2VkIHVuZGVyIHRoZSBBcGFjaGUgTGljZW5zZSwgVmVyc2lvbiAyLjAgKHRoZSBcIkxpY2Vuc2VcIik7XG55b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuXG5Zb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXRcblxuICAgIGh0dHA6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMFxuXG5Vbmxlc3MgcmVxdWlyZWQgYnkgYXBwbGljYWJsZSBsYXcgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNvZnR3YXJlXG5kaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhbiBcIkFTIElTXCIgQkFTSVMsXG5XSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTlkgS0lORCwgZWl0aGVyIGV4cHJlc3Mgb3IgaW1wbGllZC5cblNlZSB0aGUgTGljZW5zZSBmb3IgdGhlIHNwZWNpZmljIGxhbmd1YWdlIGdvdmVybmluZyBwZXJtaXNzaW9ucyBhbmRcbmxpbWl0YXRpb25zIHVuZGVyIHRoZSBMaWNlbnNlLlxuPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09Ki9cbnR5cGUgRGF0YVBvaW50ID0ge1xuICB4OiBudW1iZXI7XG4gIHk6IG51bWJlcltdO1xufVxuXG4vKipcbiAqIEEgbXVsdGktc2VyaWVzIGxpbmUgY2hhcnQgdGhhdCBhbGxvd3MgeW91IHRvIGFwcGVuZCBuZXcgZGF0YSBwb2ludHNcbiAqIGFzIGRhdGEgYmVjb21lcyBhdmFpbGFibGUuXG4gKi9cbmV4cG9ydCBjbGFzcyBBcHBlbmRpbmdMaW5lQ2hhcnQge1xuICBwcml2YXRlIG51bUxpbmVzOiBudW1iZXI7XG4gIHByaXZhdGUgZGF0YTogRGF0YVBvaW50W10gPSBbXTtcbiAgcHJpdmF0ZSBzdmc6IGQzLlNlbGVjdGlvbjxhbnk+O1xuICBwcml2YXRlIHhTY2FsZTogZDMuc2NhbGUuTGluZWFyPG51bWJlciwgbnVtYmVyPjtcbiAgcHJpdmF0ZSB5U2NhbGU6IGQzLnNjYWxlLkxpbmVhcjxudW1iZXIsIG51bWJlcj47XG4gIHByaXZhdGUgcGF0aHM6IGQzLlNlbGVjdGlvbjxhbnk+W107XG4gIHByaXZhdGUgbGluZUNvbG9yczogc3RyaW5nW107XG5cbiAgcHJpdmF0ZSBtaW5ZID0gTnVtYmVyLk1BWF9WQUxVRTtcbiAgcHJpdmF0ZSBtYXhZID0gTnVtYmVyLk1JTl9WQUxVRTtcblxuICBjb25zdHJ1Y3Rvcihjb250YWluZXI6IGQzLlNlbGVjdGlvbjxhbnk+LCBsaW5lQ29sb3JzOiBzdHJpbmdbXSkge1xuICAgIHRoaXMubGluZUNvbG9ycyA9IGxpbmVDb2xvcnM7XG4gICAgdGhpcy5udW1MaW5lcyA9IGxpbmVDb2xvcnMubGVuZ3RoO1xuICAgIGxldCBub2RlID0gPEhUTUxFbGVtZW50PmNvbnRhaW5lci5ub2RlKCk7XG4gICAgbGV0IHRvdGFsV2lkdGggPSBub2RlLm9mZnNldFdpZHRoO1xuICAgIGxldCB0b3RhbEhlaWdodCA9IG5vZGUub2Zmc2V0SGVpZ2h0O1xuICAgIGxldCBtYXJnaW4gPSB7dG9wOiAyLCByaWdodDogMCwgYm90dG9tOiAyLCBsZWZ0OiAyfTtcbiAgICBsZXQgd2lkdGggPSB0b3RhbFdpZHRoIC0gbWFyZ2luLmxlZnQgLSBtYXJnaW4ucmlnaHQ7XG4gICAgbGV0IGhlaWdodCA9IHRvdGFsSGVpZ2h0IC0gbWFyZ2luLnRvcCAtIG1hcmdpbi5ib3R0b207XG5cbiAgICB0aGlzLnhTY2FsZSA9IGQzLnNjYWxlLmxpbmVhcigpXG4gICAgICAuZG9tYWluKFswLCAwXSlcbiAgICAgIC5yYW5nZShbMCwgd2lkdGhdKTtcblxuICAgIHRoaXMueVNjYWxlID0gZDMuc2NhbGUubGluZWFyKClcbiAgICAgIC5kb21haW4oWzAsIDBdKVxuICAgICAgLnJhbmdlKFtoZWlnaHQsIDBdKTtcblxuICAgIHRoaXMuc3ZnID0gY29udGFpbmVyLmFwcGVuZChcInN2Z1wiKVxuICAgICAgLmF0dHIoXCJ3aWR0aFwiLCB3aWR0aCArIG1hcmdpbi5sZWZ0ICsgbWFyZ2luLnJpZ2h0KVxuICAgICAgLmF0dHIoXCJoZWlnaHRcIiwgaGVpZ2h0ICsgbWFyZ2luLnRvcCArIG1hcmdpbi5ib3R0b20pXG4gICAgICAuYXBwZW5kKFwiZ1wiKVxuICAgICAgICAuYXR0cihcInRyYW5zZm9ybVwiLCBgdHJhbnNsYXRlKCR7bWFyZ2luLmxlZnR9LCR7bWFyZ2luLnRvcH0pYCk7XG5cbiAgICB0aGlzLnBhdGhzID0gbmV3IEFycmF5KHRoaXMubnVtTGluZXMpO1xuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgdGhpcy5udW1MaW5lczsgaSsrKSB7XG4gICAgICB0aGlzLnBhdGhzW2ldID0gdGhpcy5zdmcuYXBwZW5kKFwicGF0aFwiKVxuICAgICAgICAuYXR0cihcImNsYXNzXCIsIFwibGluZVwiKVxuICAgICAgICAuc3R5bGUoe1xuICAgICAgICAgIFwiZmlsbFwiOiBcIm5vbmVcIixcbiAgICAgICAgICBcInN0cm9rZVwiOiBsaW5lQ29sb3JzW2ldLFxuICAgICAgICAgIFwic3Ryb2tlLXdpZHRoXCI6IFwiMS41cHhcIlxuICAgICAgICB9KTtcbiAgICB9XG4gIH1cblxuICByZXNldCgpIHtcbiAgICB0aGlzLmRhdGEgPSBbXTtcbiAgICB0aGlzLnJlZHJhdygpO1xuICAgIHRoaXMubWluWSA9IE51bWJlci5NQVhfVkFMVUU7XG4gICAgdGhpcy5tYXhZID0gTnVtYmVyLk1JTl9WQUxVRTtcbiAgfVxuXG4gIGFkZERhdGFQb2ludChkYXRhUG9pbnQ6IG51bWJlcltdKSB7XG4gICAgaWYgKGRhdGFQb2ludC5sZW5ndGggIT09IHRoaXMubnVtTGluZXMpIHtcbiAgICAgIHRocm93IEVycm9yKFwiTGVuZ3RoIG9mIGRhdGFQb2ludCBtdXN0IGVxdWFsIG51bWJlciBvZiBsaW5lc1wiKTtcbiAgICB9XG4gICAgZGF0YVBvaW50LmZvckVhY2goeSA9PiB7XG4gICAgICB0aGlzLm1pblkgPSBNYXRoLm1pbih0aGlzLm1pblksIHkpO1xuICAgICAgdGhpcy5tYXhZID0gTWF0aC5tYXgodGhpcy5tYXhZLCB5KTtcbiAgICB9KTtcblxuICAgIHRoaXMuZGF0YS5wdXNoKHt4OiB0aGlzLmRhdGEubGVuZ3RoICsgMSwgeTogZGF0YVBvaW50fSk7XG4gICAgdGhpcy5yZWRyYXcoKTtcbiAgfVxuXG4gIHByaXZhdGUgcmVkcmF3KCkge1xuICAgIC8vIEFkanVzdCB0aGUgeCBhbmQgeSBkb21haW4uXG4gICAgdGhpcy54U2NhbGUuZG9tYWluKFsxLCB0aGlzLmRhdGEubGVuZ3RoXSk7XG4gICAgdGhpcy55U2NhbGUuZG9tYWluKFt0aGlzLm1pblksIHRoaXMubWF4WV0pO1xuICAgIC8vIEFkanVzdCBhbGwgdGhlIDxwYXRoPiBlbGVtZW50cyAobGluZXMpLlxuICAgIGxldCBnZXRQYXRoTWFwID0gKGxpbmVJbmRleDogbnVtYmVyKSA9PiB7XG4gICAgICByZXR1cm4gZDMuc3ZnLmxpbmU8RGF0YVBvaW50PigpXG4gICAgICAueChkID0+IHRoaXMueFNjYWxlKGQueCkpXG4gICAgICAueShkID0+IHRoaXMueVNjYWxlKGQueVtsaW5lSW5kZXhdKSk7XG4gICAgfTtcbiAgICBmb3IgKGxldCBpID0gMDsgaSA8IHRoaXMubnVtTGluZXM7IGkrKykge1xuICAgICAgdGhpcy5wYXRoc1tpXS5kYXR1bSh0aGlzLmRhdGEpLmF0dHIoXCJkXCIsIGdldFBhdGhNYXAoaSkpO1xuICAgIH1cbiAgfVxufSIsIi8qIENvcHlyaWdodCAyMDE2IEdvb2dsZSBJbmMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQuXG5cbkxpY2Vuc2VkIHVuZGVyIHRoZSBBcGFjaGUgTGljZW5zZSwgVmVyc2lvbiAyLjAgKHRoZSBcIkxpY2Vuc2VcIik7XG55b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuXG5Zb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXRcblxuICAgIGh0dHA6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMFxuXG5Vbmxlc3MgcmVxdWlyZWQgYnkgYXBwbGljYWJsZSBsYXcgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNvZnR3YXJlXG5kaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhbiBcIkFTIElTXCIgQkFTSVMsXG5XSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTlkgS0lORCwgZWl0aGVyIGV4cHJlc3Mgb3IgaW1wbGllZC5cblNlZSB0aGUgTGljZW5zZSBmb3IgdGhlIHNwZWNpZmljIGxhbmd1YWdlIGdvdmVybmluZyBwZXJtaXNzaW9ucyBhbmRcbmxpbWl0YXRpb25zIHVuZGVyIHRoZSBMaWNlbnNlLlxuPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09Ki9cblxuLyoqXG4gKiBBIG5vZGUgaW4gYSBuZXVyYWwgbmV0d29yay4gRWFjaCBub2RlIGhhcyBhIHN0YXRlXG4gKiAodG90YWwgaW5wdXQsIG91dHB1dCwgYW5kIHRoZWlyIHJlc3BlY3RpdmVseSBkZXJpdmF0aXZlcykgd2hpY2ggY2hhbmdlc1xuICogYWZ0ZXIgZXZlcnkgZm9yd2FyZCBhbmQgYmFjayBwcm9wYWdhdGlvbiBydW4uXG4gKi9cbmV4cG9ydCBjbGFzcyBOb2RlIHtcbiAgaWQ6IHN0cmluZztcbiAgLyoqIExpc3Qgb2YgaW5wdXQgbGlua3MuICovXG4gIGlucHV0TGlua3M6IExpbmtbXSA9IFtdO1xuICBiaWFzID0gMC4xO1xuICAvKiogTGlzdCBvZiBvdXRwdXQgbGlua3MuICovXG4gIG91dHB1dHM6IExpbmtbXSA9IFtdO1xuICB0b3RhbElucHV0OiBudW1iZXI7XG4gIG91dHB1dDogbnVtYmVyO1xuICAvKiogRXJyb3IgZGVyaXZhdGl2ZSB3aXRoIHJlc3BlY3QgdG8gdGhpcyBub2RlJ3Mgb3V0cHV0LiAqL1xuICBvdXRwdXREZXIgPSAwO1xuICAvKiogRXJyb3IgZGVyaXZhdGl2ZSB3aXRoIHJlc3BlY3QgdG8gdGhpcyBub2RlJ3MgdG90YWwgaW5wdXQuICovXG4gIGlucHV0RGVyID0gMDtcbiAgLyoqXG4gICAqIEFjY3VtdWxhdGVkIGVycm9yIGRlcml2YXRpdmUgd2l0aCByZXNwZWN0IHRvIHRoaXMgbm9kZSdzIHRvdGFsIGlucHV0IHNpbmNlXG4gICAqIHRoZSBsYXN0IHVwZGF0ZS4gVGhpcyBkZXJpdmF0aXZlIGVxdWFscyBkRS9kYiB3aGVyZSBiIGlzIHRoZSBub2RlJ3NcbiAgICogYmlhcyB0ZXJtLlxuICAgKi9cbiAgYWNjSW5wdXREZXIgPSAwO1xuICAvKipcbiAgICogTnVtYmVyIG9mIGFjY3VtdWxhdGVkIGVyci4gZGVyaXZhdGl2ZXMgd2l0aCByZXNwZWN0IHRvIHRoZSB0b3RhbCBpbnB1dFxuICAgKiBzaW5jZSB0aGUgbGFzdCB1cGRhdGUuXG4gICAqL1xuICBudW1BY2N1bXVsYXRlZERlcnMgPSAwO1xuICAvKiogQWN0aXZhdGlvbiBmdW5jdGlvbiB0aGF0IHRha2VzIHRvdGFsIGlucHV0IGFuZCByZXR1cm5zIG5vZGUncyBvdXRwdXQgKi9cbiAgYWN0aXZhdGlvbjogQWN0aXZhdGlvbkZ1bmN0aW9uO1xuXG4gIC8qKlxuICAgKiBDcmVhdGVzIGEgbmV3IG5vZGUgd2l0aCB0aGUgcHJvdmlkZWQgaWQgYW5kIGFjdGl2YXRpb24gZnVuY3Rpb24uXG4gICAqL1xuICBjb25zdHJ1Y3RvcihpZDogc3RyaW5nLCBhY3RpdmF0aW9uOiBBY3RpdmF0aW9uRnVuY3Rpb24pIHtcbiAgICB0aGlzLmlkID0gaWQ7XG4gICAgdGhpcy5hY3RpdmF0aW9uID0gYWN0aXZhdGlvbjtcbiAgfVxuXG4gIC8qKiBSZWNvbXB1dGVzIHRoZSBub2RlJ3Mgb3V0cHV0IGFuZCByZXR1cm5zIGl0LiAqL1xuICB1cGRhdGVPdXRwdXQoKTogbnVtYmVyIHtcbiAgICAvLyBTdG9yZXMgdG90YWwgaW5wdXQgaW50byB0aGUgbm9kZS5cbiAgICB0aGlzLnRvdGFsSW5wdXQgPSB0aGlzLmJpYXM7XG4gICAgZm9yIChsZXQgaiA9IDA7IGogPCB0aGlzLmlucHV0TGlua3MubGVuZ3RoOyBqKyspIHtcbiAgICAgIGxldCBsaW5rID0gdGhpcy5pbnB1dExpbmtzW2pdO1xuICAgICAgdGhpcy50b3RhbElucHV0ICs9IGxpbmsud2VpZ2h0ICogbGluay5zb3VyY2Uub3V0cHV0O1xuICAgIH1cbiAgICB0aGlzLm91dHB1dCA9IHRoaXMuYWN0aXZhdGlvbi5vdXRwdXQodGhpcy50b3RhbElucHV0KTtcbiAgICByZXR1cm4gdGhpcy5vdXRwdXQ7XG4gIH1cbn1cblxuLyoqXG4gKiBBbiBlcnJvciBmdW5jdGlvbiBhbmQgaXRzIGRlcml2YXRpdmUuXG4gKi9cbmV4cG9ydCBpbnRlcmZhY2UgRXJyb3JGdW5jdGlvbiB7XG4gIGVycm9yOiAob3V0cHV0OiBudW1iZXIsIHRhcmdldDogbnVtYmVyKSA9PiBudW1iZXI7XG4gIGRlcjogKG91dHB1dDogbnVtYmVyLCB0YXJnZXQ6IG51bWJlcikgPT4gbnVtYmVyO1xufVxuXG4vKiogQSBub2RlJ3MgYWN0aXZhdGlvbiBmdW5jdGlvbiBhbmQgaXRzIGRlcml2YXRpdmUuICovXG5leHBvcnQgaW50ZXJmYWNlIEFjdGl2YXRpb25GdW5jdGlvbiB7XG4gIG91dHB1dDogKGlucHV0OiBudW1iZXIpID0+IG51bWJlcjtcbiAgZGVyOiAoaW5wdXQ6IG51bWJlcikgPT4gbnVtYmVyO1xufVxuXG4vKiogRnVuY3Rpb24gdGhhdCBjb21wdXRlcyBhIHBlbmFsdHkgY29zdCBmb3IgYSBnaXZlbiB3ZWlnaHQgaW4gdGhlIG5ldHdvcmsuICovXG5leHBvcnQgaW50ZXJmYWNlIFJlZ3VsYXJpemF0aW9uRnVuY3Rpb24ge1xuICBvdXRwdXQ6ICh3ZWlnaHQ6IG51bWJlcikgPT4gbnVtYmVyO1xuICBkZXI6ICh3ZWlnaHQ6IG51bWJlcikgPT4gbnVtYmVyO1xufVxuXG4vKiogQnVpbHQtaW4gZXJyb3IgZnVuY3Rpb25zICovXG5leHBvcnQgY2xhc3MgRXJyb3JzIHtcbiAgcHVibGljIHN0YXRpYyBTUVVBUkU6IEVycm9yRnVuY3Rpb24gPSB7XG4gICAgZXJyb3I6IChvdXRwdXQ6IG51bWJlciwgdGFyZ2V0OiBudW1iZXIpID0+XG4gICAgICAgICAgICAgICAwLjUgKiBNYXRoLnBvdyhvdXRwdXQgLSB0YXJnZXQsIDIpLFxuICAgIGRlcjogKG91dHB1dDogbnVtYmVyLCB0YXJnZXQ6IG51bWJlcikgPT4gb3V0cHV0IC0gdGFyZ2V0XG4gIH07XG59XG5cbi8qKiBQb2x5ZmlsbCBmb3IgVEFOSCAqL1xuKDxhbnk+TWF0aCkudGFuaCA9ICg8YW55Pk1hdGgpLnRhbmggfHwgZnVuY3Rpb24oeCkge1xuICBpZiAoeCA9PT0gSW5maW5pdHkpIHtcbiAgICByZXR1cm4gMTtcbiAgfSBlbHNlIGlmICh4ID09PSAtSW5maW5pdHkpIHtcbiAgICByZXR1cm4gLTE7XG4gIH0gZWxzZSB7XG4gICAgbGV0IGUyeCA9IE1hdGguZXhwKDIgKiB4KTtcbiAgICByZXR1cm4gKGUyeCAtIDEpIC8gKGUyeCArIDEpO1xuICB9XG59O1xuXG4vKiogQnVpbHQtaW4gYWN0aXZhdGlvbiBmdW5jdGlvbnMgKi9cbmV4cG9ydCBjbGFzcyBBY3RpdmF0aW9ucyB7XG4gIHB1YmxpYyBzdGF0aWMgQVJDVEFOOiBBY3RpdmF0aW9uRnVuY3Rpb24gPSB7XG4gICAgb3V0cHV0OiB4ID0+ICg8YW55Pk1hdGgpLmF0YW4oeCksXG4gICAgZGVyOiB4ID0+IDEgLyAoeCAqIHggKyAxKVxuICB9O1xuICBwdWJsaWMgc3RhdGljIEJFTlQ6IEFjdGl2YXRpb25GdW5jdGlvbiA9IHtcbiAgICBvdXRwdXQ6IHggPT4gKCg8YW55Pk1hdGgpLnNxcnQoeCAqIHggKyAxKSAtIDEpIC8gMiArIHgsXG4gICAgZGVyOiB4ID0+IHggLyAoMiooPGFueT5NYXRoKS5zcXJ0KHggKiB4ICsgMSkpICsgMVxuICB9O1xuICBwdWJsaWMgc3RhdGljIEVMVTogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiB4IDwgMCA/ICg8YW55Pk1hdGgpLmV4cCh4KSAtIDEgOiB4LFxuICAgIGRlcjogeCA9PiB7XG4gICAgICBsZXQgb3V0cHV0ID0gQWN0aXZhdGlvbnMuRUxVLm91dHB1dCh4KTtcbiAgICAgIHJldHVybiB4IDwgMCA/IG91dHB1dCArIDEgOiAxO1xuICAgIH1cbiAgfTtcbiAgcHVibGljIHN0YXRpYyBHQVVTU0lBTjogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiAoPGFueT5NYXRoKS5leHAoLXggKiB4KSxcbiAgICBkZXI6IHggPT4ge1xuICAgICAgbGV0IG91dHB1dCA9IEFjdGl2YXRpb25zLkdBVVNTSUFOLm91dHB1dCh4KTtcbiAgICAgIHJldHVybiAtMiAqIHggKiBvdXRwdXQ7XG4gICAgfVxuICB9O1xuICBwdWJsaWMgc3RhdGljIExJTkVBUjogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiB4LFxuICAgIGRlcjogeCA9PiAxXG4gIH07XG4gIHB1YmxpYyBzdGF0aWMgUkVMVTogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiAoPGFueT5NYXRoKS5tYXgoMCwgeCksXG4gICAgZGVyOiB4ID0+IHggPD0gMCA/IDAgOiAxXG4gIH07XG4gIHB1YmxpYyBzdGF0aWMgU0lHTU9JRDogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiAxIC8gKDEgKyAoPGFueT5NYXRoKS5leHAoLXgpKSxcbiAgICBkZXI6IHggPT4ge1xuICAgICAgbGV0IG91dHB1dCA9IEFjdGl2YXRpb25zLlNJR01PSUQub3V0cHV0KHgpO1xuICAgICAgcmV0dXJuIG91dHB1dCAqICgxIC0gb3V0cHV0KTtcbiAgICB9XG4gIH07XG4gIHB1YmxpYyBzdGF0aWMgU0lOVVNPSUQ6IEFjdGl2YXRpb25GdW5jdGlvbiA9IHtcbiAgICBvdXRwdXQ6IHggPT4gKDxhbnk+TWF0aCkuc2luKHgpLFxuICAgIGRlcjogeCA9PiAoPGFueT5NYXRoKS5jb3MoeClcbiAgfTtcbiAgcHVibGljIHN0YXRpYyBTT0ZUUExVUzogQWN0aXZhdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogeCA9PiAoPGFueT5NYXRoKS5sb2coMSArICg8YW55Pk1hdGgpLmV4cCh4KSksXG4gICAgZGVyOiB4ID0+IEFjdGl2YXRpb25zLlNJR01PSUQub3V0cHV0KHgpXG4gIH07XG4gIHB1YmxpYyBzdGF0aWMgU09GVFNJR046IEFjdGl2YXRpb25GdW5jdGlvbiA9IHtcbiAgICBvdXRwdXQ6IHggPT4geCAvICgxICsgKDxhbnk+TWF0aCkuYWJzKHgpKSxcbiAgICBkZXI6IHggPT4ge1xuICAgICAgbGV0IHJvb3QgPSAxIC8gKDEgKyAoPGFueT5NYXRoKS5hYnMoeCkpO1xuICAgICAgcmV0dXJuIHJvb3QgKiByb290O1xuICAgIH1cbiAgfTtcbiAgcHVibGljIHN0YXRpYyBUQU5IOiBBY3RpdmF0aW9uRnVuY3Rpb24gPSB7XG4gICAgb3V0cHV0OiB4ID0+ICg8YW55Pk1hdGgpLnRhbmgoeCksXG4gICAgZGVyOiB4ID0+IHtcbiAgICAgIGxldCBvdXRwdXQgPSBBY3RpdmF0aW9ucy5UQU5ILm91dHB1dCh4KTtcbiAgICAgIHJldHVybiAxIC0gb3V0cHV0ICogb3V0cHV0O1xuICAgIH1cbiAgfTtcbn1cblxuLyoqIEJ1aWxkLWluIHJlZ3VsYXJpemF0aW9uIGZ1bmN0aW9ucyAqL1xuZXhwb3J0IGNsYXNzIFJlZ3VsYXJpemF0aW9uRnVuY3Rpb24ge1xuICBwdWJsaWMgc3RhdGljIEwxOiBSZWd1bGFyaXphdGlvbkZ1bmN0aW9uID0ge1xuICAgIG91dHB1dDogdyA9PiBNYXRoLmFicyh3KSxcbiAgICBkZXI6IHcgPT4gdyA8IDAgPyAtMSA6IDFcbiAgfTtcbiAgcHVibGljIHN0YXRpYyBMMjogUmVndWxhcml6YXRpb25GdW5jdGlvbiA9IHtcbiAgICBvdXRwdXQ6IHcgPT4gMC41ICogdyAqIHcsXG4gICAgZGVyOiB3ID0+IHdcbiAgfTtcbn1cblxuLyoqXG4gKiBBIGxpbmsgaW4gYSBuZXVyYWwgbmV0d29yay4gRWFjaCBsaW5rIGhhcyBhIHdlaWdodCBhbmQgYSBzb3VyY2UgYW5kXG4gKiBkZXN0aW5hdGlvbiBub2RlLiBBbHNvIGl0IGhhcyBhbiBpbnRlcm5hbCBzdGF0ZSAoZXJyb3IgZGVyaXZhdGl2ZVxuICogd2l0aCByZXNwZWN0IHRvIGEgcGFydGljdWxhciBpbnB1dCkgd2hpY2ggZ2V0cyB1cGRhdGVkIGFmdGVyXG4gKiBhIHJ1biBvZiBiYWNrIHByb3BhZ2F0aW9uLlxuICovXG5leHBvcnQgY2xhc3MgTGluayB7XG4gIGlkOiBzdHJpbmc7XG4gIHNvdXJjZTogTm9kZTtcbiAgZGVzdDogTm9kZTtcbiAgd2VpZ2h0ID0gTWF0aC5yYW5kb20oKSAtIDAuNTtcbiAgLyoqIEVycm9yIGRlcml2YXRpdmUgd2l0aCByZXNwZWN0IHRvIHRoaXMgd2VpZ2h0LiAqL1xuICBlcnJvckRlciA9IDA7XG4gIC8qKiBBY2N1bXVsYXRlZCBlcnJvciBkZXJpdmF0aXZlIHNpbmNlIHRoZSBsYXN0IHVwZGF0ZS4gKi9cbiAgYWNjRXJyb3JEZXIgPSAwO1xuICAvKiogTnVtYmVyIG9mIGFjY3VtdWxhdGVkIGRlcml2YXRpdmVzIHNpbmNlIHRoZSBsYXN0IHVwZGF0ZS4gKi9cbiAgbnVtQWNjdW11bGF0ZWREZXJzID0gMDtcbiAgcmVndWxhcml6YXRpb246IFJlZ3VsYXJpemF0aW9uRnVuY3Rpb247XG5cbiAgLyoqXG4gICAqIENvbnN0cnVjdHMgYSBsaW5rIGluIHRoZSBuZXVyYWwgbmV0d29yayBpbml0aWFsaXplZCB3aXRoIHJhbmRvbSB3ZWlnaHQuXG4gICAqXG4gICAqIEBwYXJhbSBzb3VyY2UgVGhlIHNvdXJjZSBub2RlLlxuICAgKiBAcGFyYW0gZGVzdCBUaGUgZGVzdGluYXRpb24gbm9kZS5cbiAgICogQHBhcmFtIHJlZ3VsYXJpemF0aW9uIFRoZSByZWd1bGFyaXphdGlvbiBmdW5jdGlvbiB0aGF0IGNvbXB1dGVzIHRoZVxuICAgKiAgICAgcGVuYWx0eSBmb3IgdGhpcyB3ZWlnaHQuIElmIG51bGwsIHRoZXJlIHdpbGwgYmUgbm8gcmVndWxhcml6YXRpb24uXG4gICAqL1xuICBjb25zdHJ1Y3Rvcihzb3VyY2U6IE5vZGUsIGRlc3Q6IE5vZGUsXG4gICAgICByZWd1bGFyaXphdGlvbjogUmVndWxhcml6YXRpb25GdW5jdGlvbikge1xuICAgIHRoaXMuaWQgPSBzb3VyY2UuaWQgKyBcIi1cIiArIGRlc3QuaWQ7XG4gICAgdGhpcy5zb3VyY2UgPSBzb3VyY2U7XG4gICAgdGhpcy5kZXN0ID0gZGVzdDtcbiAgICB0aGlzLnJlZ3VsYXJpemF0aW9uID0gcmVndWxhcml6YXRpb247XG4gIH1cbn1cblxuLyoqXG4gKiBCdWlsZHMgYSBuZXVyYWwgbmV0d29yay5cbiAqXG4gKiBAcGFyYW0gbmV0d29ya1NoYXBlIFRoZSBzaGFwZSBvZiB0aGUgbmV0d29yay4gRS5nLiBbMSwgMiwgMywgMV0gbWVhbnNcbiAqICAgdGhlIG5ldHdvcmsgd2lsbCBoYXZlIG9uZSBpbnB1dCBub2RlLCAyIG5vZGVzIGluIGZpcnN0IGhpZGRlbiBsYXllcixcbiAqICAgMyBub2RlcyBpbiBzZWNvbmQgaGlkZGVuIGxheWVyIGFuZCAxIG91dHB1dCBub2RlLlxuICogQHBhcmFtIGFjdGl2YXRpb24gVGhlIGFjdGl2YXRpb24gZnVuY3Rpb24gb2YgZXZlcnkgaGlkZGVuIG5vZGUuXG4gKiBAcGFyYW0gb3V0cHV0QWN0aXZhdGlvbiBUaGUgYWN0aXZhdGlvbiBmdW5jdGlvbiBmb3IgdGhlIG91dHB1dCBub2Rlcy5cbiAqIEBwYXJhbSByZWd1bGFyaXphdGlvbiBUaGUgcmVndWxhcml6YXRpb24gZnVuY3Rpb24gdGhhdCBjb21wdXRlcyBhIHBlbmFsdHlcbiAqICAgICBmb3IgYSBnaXZlbiB3ZWlnaHQgKHBhcmFtZXRlcikgaW4gdGhlIG5ldHdvcmsuIElmIG51bGwsIHRoZXJlIHdpbGwgYmVcbiAqICAgICBubyByZWd1bGFyaXphdGlvbi5cbiAqIEBwYXJhbSBpbnB1dElkcyBMaXN0IG9mIGlkcyBmb3IgdGhlIGlucHV0IG5vZGVzLlxuICovXG5leHBvcnQgZnVuY3Rpb24gYnVpbGROZXR3b3JrKFxuICAgIG5ldHdvcmtTaGFwZTogbnVtYmVyW10sIGFjdGl2YXRpb246IEFjdGl2YXRpb25GdW5jdGlvbixcbiAgICBvdXRwdXRBY3RpdmF0aW9uOiBBY3RpdmF0aW9uRnVuY3Rpb24sXG4gICAgcmVndWxhcml6YXRpb246IFJlZ3VsYXJpemF0aW9uRnVuY3Rpb24sXG4gICAgaW5wdXRJZHM6IHN0cmluZ1tdKTogTm9kZVtdW10ge1xuICBsZXQgbnVtTGF5ZXJzID0gbmV0d29ya1NoYXBlLmxlbmd0aDtcbiAgbGV0IGlkID0gMTtcbiAgLyoqIExpc3Qgb2YgbGF5ZXJzLCB3aXRoIGVhY2ggbGF5ZXIgYmVpbmcgYSBsaXN0IG9mIG5vZGVzLiAqL1xuICBsZXQgbmV0d29yazogTm9kZVtdW10gPSBbXTtcbiAgZm9yIChsZXQgbGF5ZXJJZHggPSAwOyBsYXllcklkeCA8IG51bUxheWVyczsgbGF5ZXJJZHgrKykge1xuICAgIGxldCBpc091dHB1dExheWVyID0gbGF5ZXJJZHggPT09IG51bUxheWVycyAtIDE7XG4gICAgbGV0IGlzSW5wdXRMYXllciA9IGxheWVySWR4ID09PSAwO1xuICAgIGxldCBjdXJyZW50TGF5ZXI6IE5vZGVbXSA9IFtdO1xuICAgIG5ldHdvcmsucHVzaChjdXJyZW50TGF5ZXIpO1xuICAgIGxldCBudW1Ob2RlcyA9IG5ldHdvcmtTaGFwZVtsYXllcklkeF07XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBudW1Ob2RlczsgaSsrKSB7XG4gICAgICBsZXQgbm9kZUlkID0gaWQudG9TdHJpbmcoKTtcbiAgICAgIGlmIChpc0lucHV0TGF5ZXIpIHtcbiAgICAgICAgbm9kZUlkID0gaW5wdXRJZHNbaV07XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBpZCsrO1xuICAgICAgfVxuICAgICAgbGV0IG5vZGUgPSBuZXcgTm9kZShub2RlSWQsXG4gICAgICAgICAgaXNPdXRwdXRMYXllciA/IG91dHB1dEFjdGl2YXRpb24gOiBhY3RpdmF0aW9uKTtcbiAgICAgIGN1cnJlbnRMYXllci5wdXNoKG5vZGUpO1xuICAgICAgaWYgKGxheWVySWR4ID49IDEpIHtcbiAgICAgICAgLy8gQWRkIGxpbmtzIGZyb20gbm9kZXMgaW4gdGhlIHByZXZpb3VzIGxheWVyIHRvIHRoaXMgbm9kZS5cbiAgICAgICAgZm9yIChsZXQgaiA9IDA7IGogPCBuZXR3b3JrW2xheWVySWR4IC0gMV0ubGVuZ3RoOyBqKyspIHtcbiAgICAgICAgICBsZXQgcHJldk5vZGUgPSBuZXR3b3JrW2xheWVySWR4IC0gMV1bal07XG4gICAgICAgICAgbGV0IGxpbmsgPSBuZXcgTGluayhwcmV2Tm9kZSwgbm9kZSwgcmVndWxhcml6YXRpb24pO1xuICAgICAgICAgIHByZXZOb2RlLm91dHB1dHMucHVzaChsaW5rKTtcbiAgICAgICAgICBub2RlLmlucHV0TGlua3MucHVzaChsaW5rKTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfVxuICByZXR1cm4gbmV0d29yaztcbn1cblxuLyoqXG4gKiBSdW5zIGEgZm9yd2FyZCBwcm9wYWdhdGlvbiBvZiB0aGUgcHJvdmlkZWQgaW5wdXQgdGhyb3VnaCB0aGUgcHJvdmlkZWRcbiAqIG5ldHdvcmsuIFRoaXMgbWV0aG9kIG1vZGlmaWVzIHRoZSBpbnRlcm5hbCBzdGF0ZSBvZiB0aGUgbmV0d29yayAtIHRoZVxuICogdG90YWwgaW5wdXQgYW5kIG91dHB1dCBvZiBlYWNoIG5vZGUgaW4gdGhlIG5ldHdvcmsuXG4gKlxuICogQHBhcmFtIG5ldHdvcmsgVGhlIG5ldXJhbCBuZXR3b3JrLlxuICogQHBhcmFtIGlucHV0cyBUaGUgaW5wdXQgYXJyYXkuIEl0cyBsZW5ndGggc2hvdWxkIG1hdGNoIHRoZSBudW1iZXIgb2YgaW5wdXRcbiAqICAgICBub2RlcyBpbiB0aGUgbmV0d29yay5cbiAqIEByZXR1cm4gVGhlIGZpbmFsIG91dHB1dCBvZiB0aGUgbmV0d29yay5cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGZvcndhcmRQcm9wKG5ldHdvcms6IE5vZGVbXVtdLCBpbnB1dHM6IG51bWJlcltdKTogbnVtYmVyIHtcbiAgbGV0IGlucHV0TGF5ZXIgPSBuZXR3b3JrWzBdO1xuICBpZiAoaW5wdXRzLmxlbmd0aCAhPT0gaW5wdXRMYXllci5sZW5ndGgpIHtcbiAgICB0aHJvdyBuZXcgRXJyb3IoXCJUaGUgbnVtYmVyIG9mIGlucHV0cyBtdXN0IG1hdGNoIHRoZSBudW1iZXIgb2Ygbm9kZXMgaW5cIiArXG4gICAgICAgIFwiIHRoZSBpbnB1dCBsYXllclwiKTtcbiAgfVxuICAvLyBVcGRhdGUgdGhlIGlucHV0IGxheWVyLlxuICBmb3IgKGxldCBpID0gMDsgaSA8IGlucHV0TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICBsZXQgbm9kZSA9IGlucHV0TGF5ZXJbaV07XG4gICAgbm9kZS5vdXRwdXQgPSBpbnB1dHNbaV07XG4gIH1cbiAgZm9yIChsZXQgbGF5ZXJJZHggPSAxOyBsYXllcklkeCA8IG5ldHdvcmsubGVuZ3RoOyBsYXllcklkeCsrKSB7XG4gICAgbGV0IGN1cnJlbnRMYXllciA9IG5ldHdvcmtbbGF5ZXJJZHhdO1xuICAgIC8vIFVwZGF0ZSBhbGwgdGhlIG5vZGVzIGluIHRoaXMgbGF5ZXIuXG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjdXJyZW50TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGxldCBub2RlID0gY3VycmVudExheWVyW2ldO1xuICAgICAgbm9kZS51cGRhdGVPdXRwdXQoKTtcbiAgICB9XG4gIH1cbiAgcmV0dXJuIG5ldHdvcmtbbmV0d29yay5sZW5ndGggLSAxXVswXS5vdXRwdXQ7XG59XG5cbi8qKlxuICogUnVucyBhIGJhY2t3YXJkIHByb3BhZ2F0aW9uIHVzaW5nIHRoZSBwcm92aWRlZCB0YXJnZXQgYW5kIHRoZVxuICogY29tcHV0ZWQgb3V0cHV0IG9mIHRoZSBwcmV2aW91cyBjYWxsIHRvIGZvcndhcmQgcHJvcGFnYXRpb24uXG4gKiBUaGlzIG1ldGhvZCBtb2RpZmllcyB0aGUgaW50ZXJuYWwgc3RhdGUgb2YgdGhlIG5ldHdvcmsgLSB0aGUgZXJyb3JcbiAqIGRlcml2YXRpdmVzIHdpdGggcmVzcGVjdCB0byBlYWNoIG5vZGUsIGFuZCBlYWNoIHdlaWdodFxuICogaW4gdGhlIG5ldHdvcmsuXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBiYWNrUHJvcChuZXR3b3JrOiBOb2RlW11bXSwgdGFyZ2V0OiBudW1iZXIsXG4gICAgZXJyb3JGdW5jOiBFcnJvckZ1bmN0aW9uKTogdm9pZCB7XG4gIC8vIFRoZSBvdXRwdXQgbm9kZSBpcyBhIHNwZWNpYWwgY2FzZS4gV2UgdXNlIHRoZSB1c2VyLWRlZmluZWQgZXJyb3JcbiAgLy8gZnVuY3Rpb24gZm9yIHRoZSBkZXJpdmF0aXZlLlxuICBsZXQgb3V0cHV0Tm9kZSA9IG5ldHdvcmtbbmV0d29yay5sZW5ndGggLSAxXVswXTtcbiAgb3V0cHV0Tm9kZS5vdXRwdXREZXIgPSBlcnJvckZ1bmMuZGVyKG91dHB1dE5vZGUub3V0cHV0LCB0YXJnZXQpO1xuXG4gIC8vIEdvIHRocm91Z2ggdGhlIGxheWVycyBiYWNrd2FyZHMuXG4gIGZvciAobGV0IGxheWVySWR4ID0gbmV0d29yay5sZW5ndGggLSAxOyBsYXllcklkeCA+PSAxOyBsYXllcklkeC0tKSB7XG4gICAgbGV0IGN1cnJlbnRMYXllciA9IG5ldHdvcmtbbGF5ZXJJZHhdO1xuICAgIC8vIENvbXB1dGUgdGhlIGVycm9yIGRlcml2YXRpdmUgb2YgZWFjaCBub2RlIHdpdGggcmVzcGVjdCB0bzpcbiAgICAvLyAxKSBpdHMgdG90YWwgaW5wdXRcbiAgICAvLyAyKSBlYWNoIG9mIGl0cyBpbnB1dCB3ZWlnaHRzLlxuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgY3VycmVudExheWVyLmxlbmd0aDsgaSsrKSB7XG4gICAgICBsZXQgbm9kZSA9IGN1cnJlbnRMYXllcltpXTtcbiAgICAgIG5vZGUuaW5wdXREZXIgPSBub2RlLm91dHB1dERlciAqIG5vZGUuYWN0aXZhdGlvbi5kZXIobm9kZS50b3RhbElucHV0KTtcbiAgICAgIG5vZGUuYWNjSW5wdXREZXIgKz0gbm9kZS5pbnB1dERlcjtcbiAgICAgIG5vZGUubnVtQWNjdW11bGF0ZWREZXJzKys7XG4gICAgfVxuXG4gICAgLy8gRXJyb3IgZGVyaXZhdGl2ZSB3aXRoIHJlc3BlY3QgdG8gZWFjaCB3ZWlnaHQgY29taW5nIGludG8gdGhlIG5vZGUuXG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjdXJyZW50TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGxldCBub2RlID0gY3VycmVudExheWVyW2ldO1xuICAgICAgZm9yIChsZXQgaiA9IDA7IGogPCBub2RlLmlucHV0TGlua3MubGVuZ3RoOyBqKyspIHtcbiAgICAgICAgbGV0IGxpbmsgPSBub2RlLmlucHV0TGlua3Nbal07XG4gICAgICAgIGxpbmsuZXJyb3JEZXIgPSBub2RlLmlucHV0RGVyICogbGluay5zb3VyY2Uub3V0cHV0O1xuICAgICAgICBsaW5rLmFjY0Vycm9yRGVyICs9IGxpbmsuZXJyb3JEZXI7XG4gICAgICAgIGxpbmsubnVtQWNjdW11bGF0ZWREZXJzKys7XG4gICAgICB9XG4gICAgfVxuICAgIGlmIChsYXllcklkeCA9PT0gMSkge1xuICAgICAgY29udGludWU7XG4gICAgfVxuICAgIGxldCBwcmV2TGF5ZXIgPSBuZXR3b3JrW2xheWVySWR4IC0gMV07XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBwcmV2TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGxldCBub2RlID0gcHJldkxheWVyW2ldO1xuICAgICAgLy8gQ29tcHV0ZSB0aGUgZXJyb3IgZGVyaXZhdGl2ZSB3aXRoIHJlc3BlY3QgdG8gZWFjaCBub2RlJ3Mgb3V0cHV0LlxuICAgICAgbm9kZS5vdXRwdXREZXIgPSAwO1xuICAgICAgZm9yIChsZXQgaiA9IDA7IGogPCBub2RlLm91dHB1dHMubGVuZ3RoOyBqKyspIHtcbiAgICAgICAgbGV0IG91dHB1dCA9IG5vZGUub3V0cHV0c1tqXTtcbiAgICAgICAgbm9kZS5vdXRwdXREZXIgKz0gb3V0cHV0LndlaWdodCAqIG91dHB1dC5kZXN0LmlucHV0RGVyO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG4vKipcbiAqIFVwZGF0ZXMgdGhlIHdlaWdodHMgb2YgdGhlIG5ldHdvcmsgdXNpbmcgdGhlIHByZXZpb3VzbHkgYWNjdW11bGF0ZWQgZXJyb3JcbiAqIGRlcml2YXRpdmVzLlxuICovXG5leHBvcnQgZnVuY3Rpb24gdXBkYXRlV2VpZ2h0cyhuZXR3b3JrOiBOb2RlW11bXSwgbGVhcm5pbmdSYXRlOiBudW1iZXIsXG4gICAgcmVndWxhcml6YXRpb25SYXRlOiBudW1iZXIpIHtcbiAgZm9yIChsZXQgbGF5ZXJJZHggPSAxOyBsYXllcklkeCA8IG5ldHdvcmsubGVuZ3RoOyBsYXllcklkeCsrKSB7XG4gICAgbGV0IGN1cnJlbnRMYXllciA9IG5ldHdvcmtbbGF5ZXJJZHhdO1xuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgY3VycmVudExheWVyLmxlbmd0aDsgaSsrKSB7XG4gICAgICBsZXQgbm9kZSA9IGN1cnJlbnRMYXllcltpXTtcbiAgICAgIC8vIFVwZGF0ZSB0aGUgbm9kZSdzIGJpYXMuXG4gICAgICBpZiAobm9kZS5udW1BY2N1bXVsYXRlZERlcnMgPiAwKSB7XG4gICAgICAgIG5vZGUuYmlhcyAtPSBsZWFybmluZ1JhdGUgKiBub2RlLmFjY0lucHV0RGVyIC8gbm9kZS5udW1BY2N1bXVsYXRlZERlcnM7XG4gICAgICAgIG5vZGUuYWNjSW5wdXREZXIgPSAwO1xuICAgICAgICBub2RlLm51bUFjY3VtdWxhdGVkRGVycyA9IDA7XG4gICAgICB9XG4gICAgICAvLyBVcGRhdGUgdGhlIHdlaWdodHMgY29taW5nIGludG8gdGhpcyBub2RlLlxuICAgICAgZm9yIChsZXQgaiA9IDA7IGogPCBub2RlLmlucHV0TGlua3MubGVuZ3RoOyBqKyspIHtcbiAgICAgICAgbGV0IGxpbmsgPSBub2RlLmlucHV0TGlua3Nbal07XG4gICAgICAgIGxldCByZWd1bERlciA9IGxpbmsucmVndWxhcml6YXRpb24gP1xuICAgICAgICAgICAgbGluay5yZWd1bGFyaXphdGlvbi5kZXIobGluay53ZWlnaHQpIDogMDtcbiAgICAgICAgaWYgKGxpbmsubnVtQWNjdW11bGF0ZWREZXJzID4gMCkge1xuICAgICAgICAgIGxpbmsud2VpZ2h0IC09IChsZWFybmluZ1JhdGUgLyBsaW5rLm51bUFjY3VtdWxhdGVkRGVycykgKlxuICAgICAgICAgICAgKGxpbmsuYWNjRXJyb3JEZXIgKyByZWd1bGFyaXphdGlvblJhdGUgKiByZWd1bERlcik7XG4gICAgICAgICAgbGluay5hY2NFcnJvckRlciA9IDA7XG4gICAgICAgICAgbGluay5udW1BY2N1bXVsYXRlZERlcnMgPSAwO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgfVxuICB9XG59XG5cbi8qKiBJdGVyYXRlcyBvdmVyIGV2ZXJ5IG5vZGUgaW4gdGhlIG5ldHdvcmsvICovXG5leHBvcnQgZnVuY3Rpb24gZm9yRWFjaE5vZGUobmV0d29yazogTm9kZVtdW10sIGlnbm9yZUlucHV0czogYm9vbGVhbixcbiAgICBhY2Nlc3NvcjogKG5vZGU6IE5vZGUpID0+IGFueSkge1xuICBmb3IgKGxldCBsYXllcklkeCA9IGlnbm9yZUlucHV0cyA/IDEgOiAwO1xuICAgICAgbGF5ZXJJZHggPCBuZXR3b3JrLmxlbmd0aDtcbiAgICAgIGxheWVySWR4KyspIHtcbiAgICBsZXQgY3VycmVudExheWVyID0gbmV0d29ya1tsYXllcklkeF07XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjdXJyZW50TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGxldCBub2RlID0gY3VycmVudExheWVyW2ldO1xuICAgICAgYWNjZXNzb3Iobm9kZSk7XG4gICAgfVxuICB9XG59XG5cbi8qKiBSZXR1cm5zIHRoZSBvdXRwdXQgbm9kZSBpbiB0aGUgbmV0d29yay4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRPdXRwdXROb2RlKG5ldHdvcms6IE5vZGVbXVtdKSB7XG4gIHJldHVybiBuZXR3b3JrW25ldHdvcmsubGVuZ3RoIC0gMV1bMF07XG59XG4iLCIvKiBDb3B5cmlnaHQgMjAxNiBHb29nbGUgSW5jLiBBbGwgUmlnaHRzIFJlc2VydmVkLlxuXG5MaWNlbnNlZCB1bmRlciB0aGUgQXBhY2hlIExpY2Vuc2UsIFZlcnNpb24gMi4wICh0aGUgXCJMaWNlbnNlXCIpO1xueW91IG1heSBub3QgdXNlIHRoaXMgZmlsZSBleGNlcHQgaW4gY29tcGxpYW5jZSB3aXRoIHRoZSBMaWNlbnNlLlxuWW91IG1heSBvYnRhaW4gYSBjb3B5IG9mIHRoZSBMaWNlbnNlIGF0XG5cbiAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvTElDRU5TRS0yLjBcblxuVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZVxuZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gXCJBUyBJU1wiIEJBU0lTLFxuV0lUSE9VVCBXQVJSQU5USUVTIE9SIENPTkRJVElPTlMgT0YgQU5ZIEtJTkQsIGVpdGhlciBleHByZXNzIG9yIGltcGxpZWQuXG5TZWUgdGhlIExpY2Vuc2UgZm9yIHRoZSBzcGVjaWZpYyBsYW5ndWFnZSBnb3Zlcm5pbmcgcGVybWlzc2lvbnMgYW5kXG5saW1pdGF0aW9ucyB1bmRlciB0aGUgTGljZW5zZS5cbj09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSovXG5cbi8vLyA8cmVmZXJlbmNlIHBhdGg9XCJ0eXBpbmdzL2Jyb3dzZXIuZC50c1wiIC8+XG4vLy8gPHJlZmVyZW5jZSBwYXRoPVwic2VlZHJhbmRvbS5kLnRzXCIgLz5cblxuaW1wb3J0ICogYXMgbm4gZnJvbSBcIi4vbm5cIjtcbmltcG9ydCB7SGVhdE1hcCwgcmVkdWNlTWF0cml4fSBmcm9tIFwiLi9oZWF0bWFwXCI7XG5pbXBvcnQge1xuICBTdGF0ZSxcbiAgZGF0YXNldHMsXG4gIHJlZ0RhdGFzZXRzLFxuICBhY3RpdmF0aW9ucyxcbiAgcHJvYmxlbXMsXG4gIHJlZ3VsYXJpemF0aW9ucyxcbiAgZ2V0S2V5RnJvbVZhbHVlLFxuICBQcm9ibGVtXG59IGZyb20gXCIuL3N0YXRlXCI7XG5pbXBvcnQge0V4YW1wbGUyRCwgc2h1ZmZsZX0gZnJvbSBcIi4vZGF0YXNldFwiO1xuaW1wb3J0IHtBcHBlbmRpbmdMaW5lQ2hhcnR9IGZyb20gXCIuL2xpbmVjaGFydFwiO1xuXG5sZXQgbWFpbldpZHRoO1xuXG4vLyBNb3JlIHNjcm9sbGluZ1xuZDMuc2VsZWN0KFwiLm1vcmUgYnV0dG9uXCIpLm9uKFwiY2xpY2tcIiwgZnVuY3Rpb24oKSB7XG4gIGxldCBwb3NpdGlvbiA9IDgwMDtcbiAgZDMudHJhbnNpdGlvbigpXG4gICAgLmR1cmF0aW9uKDEwMDApXG4gICAgLnR3ZWVuKFwic2Nyb2xsXCIsIHNjcm9sbFR3ZWVuKHBvc2l0aW9uKSk7XG59KTtcblxuZnVuY3Rpb24gc2Nyb2xsVHdlZW4ob2Zmc2V0KSB7XG4gIHJldHVybiBmdW5jdGlvbigpIHtcbiAgICBsZXQgaSA9IGQzLmludGVycG9sYXRlTnVtYmVyKHdpbmRvdy5wYWdlWU9mZnNldCB8fFxuICAgICAgICBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuc2Nyb2xsVG9wLCBvZmZzZXQpO1xuICAgIHJldHVybiBmdW5jdGlvbih0KSB7IHNjcm9sbFRvKDAsIGkodCkpOyB9O1xuICB9O1xufVxuXG5jb25zdCBSRUNUX1NJWkUgPSAzMDtcbmNvbnN0IEJJQVNfU0laRSA9IDU7XG5jb25zdCBOVU1fU0FNUExFU19DTEFTU0lGWSA9IDUwMDtcbmNvbnN0IE5VTV9TQU1QTEVTX1JFR1JFU1MgPSAxMjAwO1xuY29uc3QgREVOU0lUWSA9IDEwMDtcblxuZW51bSBIb3ZlclR5cGUge1xuICBCSUFTLCBXRUlHSFRcbn1cblxuaW50ZXJmYWNlIElucHV0RmVhdHVyZSB7XG4gIGY6ICh4OiBudW1iZXIsIHk6IG51bWJlcikgPT4gbnVtYmVyO1xuICBsYWJlbD86IHN0cmluZztcbn1cblxubGV0IElOUFVUUzoge1tuYW1lOiBzdHJpbmddOiBJbnB1dEZlYXR1cmV9ID0ge1xuICBcInhcIjoge2Y6ICh4LCB5KSA9PiB4LCBsYWJlbDogXCJYXzFcIn0sXG4gIFwieVwiOiB7ZjogKHgsIHkpID0+IHksIGxhYmVsOiBcIlhfMlwifSxcbiAgXCJ4U3F1YXJlZFwiOiB7ZjogKHgsIHkpID0+IHggKiB4LCBsYWJlbDogXCJYXzFeMlwifSxcbiAgXCJ5U3F1YXJlZFwiOiB7ZjogKHgsIHkpID0+IHkgKiB5LCAgbGFiZWw6IFwiWF8yXjJcIn0sXG4gIFwieFRpbWVzWVwiOiB7ZjogKHgsIHkpID0+IHggKiB5LCBsYWJlbDogXCJYXzFYXzJcIn0sXG4gIFwic2luWFwiOiB7ZjogKHgsIHkpID0+IE1hdGguc2luKHgpLCBsYWJlbDogXCJzaW4oWF8xKVwifSxcbiAgXCJzaW5ZXCI6IHtmOiAoeCwgeSkgPT4gTWF0aC5zaW4oeSksIGxhYmVsOiBcInNpbihYXzIpXCJ9LFxufTtcblxubGV0IEhJREFCTEVfQ09OVFJPTFMgPSBbXG4gIFtcIlNob3cgdGVzdCBkYXRhXCIsIFwic2hvd1Rlc3REYXRhXCJdLFxuICBbXCJEaXNjcmV0aXplIG91dHB1dFwiLCBcImRpc2NyZXRpemVcIl0sXG4gIFtcIlBsYXkgYnV0dG9uXCIsIFwicGxheUJ1dHRvblwiXSxcbiAgW1wiU3RlcCBidXR0b25cIiwgXCJzdGVwQnV0dG9uXCJdLFxuICBbXCJSZXNldCBidXR0b25cIiwgXCJyZXNldEJ1dHRvblwiXSxcbiAgW1wiTGVhcm5pbmcgcmF0ZVwiLCBcImxlYXJuaW5nUmF0ZVwiXSxcbiAgW1wiQWN0aXZhdGlvblwiLCBcImFjdGl2YXRpb25cIl0sXG4gIFtcIlJlZ3VsYXJpemF0aW9uXCIsIFwicmVndWxhcml6YXRpb25cIl0sXG4gIFtcIlJlZ3VsYXJpemF0aW9uIHJhdGVcIiwgXCJyZWd1bGFyaXphdGlvblJhdGVcIl0sXG4gIFtcIlByb2JsZW0gdHlwZVwiLCBcInByb2JsZW1cIl0sXG4gIFtcIldoaWNoIGRhdGFzZXRcIiwgXCJkYXRhc2V0XCJdLFxuICBbXCJSYXRpbyB0cmFpbiBkYXRhXCIsIFwicGVyY1RyYWluRGF0YVwiXSxcbiAgW1wiTm9pc2UgbGV2ZWxcIiwgXCJub2lzZVwiXSxcbiAgW1wiQmF0Y2ggc2l6ZVwiLCBcImJhdGNoU2l6ZVwiXSxcbiAgW1wiIyBvZiBoaWRkZW4gbGF5ZXJzXCIsIFwibnVtSGlkZGVuTGF5ZXJzXCJdLFxuXTtcblxuY2xhc3MgUGxheWVyIHtcbiAgcHJpdmF0ZSB0aW1lckluZGV4ID0gMDtcbiAgcHJpdmF0ZSBpc1BsYXlpbmcgPSBmYWxzZTtcbiAgcHJpdmF0ZSBjYWxsYmFjazogKGlzUGxheWluZzogYm9vbGVhbikgPT4gdm9pZCA9IG51bGw7XG5cbiAgLyoqIFBsYXlzL3BhdXNlcyB0aGUgcGxheWVyLiAqL1xuICBwbGF5T3JQYXVzZSgpIHtcbiAgICBpZiAodGhpcy5pc1BsYXlpbmcpIHtcbiAgICAgIHRoaXMuaXNQbGF5aW5nID0gZmFsc2U7XG4gICAgICB0aGlzLnBhdXNlKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHRoaXMuaXNQbGF5aW5nID0gdHJ1ZTtcbiAgICAgIHRoaXMucGxheSgpO1xuICAgIH1cbiAgfVxuXG4gIG9uUGxheVBhdXNlKGNhbGxiYWNrOiAoaXNQbGF5aW5nOiBib29sZWFuKSA9PiB2b2lkKSB7XG4gICAgdGhpcy5jYWxsYmFjayA9IGNhbGxiYWNrO1xuICB9XG5cbiAgcGxheSgpIHtcbiAgICB0aGlzLnBhdXNlKCk7XG4gICAgdGhpcy5pc1BsYXlpbmcgPSB0cnVlO1xuICAgIGlmICh0aGlzLmNhbGxiYWNrKSB7XG4gICAgICB0aGlzLmNhbGxiYWNrKHRoaXMuaXNQbGF5aW5nKTtcbiAgICB9XG4gICAgdGhpcy5zdGFydCh0aGlzLnRpbWVySW5kZXgpO1xuICB9XG5cbiAgcGF1c2UoKSB7XG4gICAgdGhpcy50aW1lckluZGV4Kys7XG4gICAgdGhpcy5pc1BsYXlpbmcgPSBmYWxzZTtcbiAgICBpZiAodGhpcy5jYWxsYmFjaykge1xuICAgICAgdGhpcy5jYWxsYmFjayh0aGlzLmlzUGxheWluZyk7XG4gICAgfVxuICB9XG5cbiAgcHJpdmF0ZSBzdGFydChsb2NhbFRpbWVySW5kZXg6IG51bWJlcikge1xuICAgIGQzLnRpbWVyKCgpID0+IHtcbiAgICAgIGlmIChsb2NhbFRpbWVySW5kZXggPCB0aGlzLnRpbWVySW5kZXgpIHtcbiAgICAgICAgcmV0dXJuIHRydWU7ICAvLyBEb25lLlxuICAgICAgfVxuICAgICAgb25lU3RlcCgpO1xuICAgICAgcmV0dXJuIGZhbHNlOyAgLy8gTm90IGRvbmUuXG4gICAgfSwgMCk7XG4gIH1cbn1cblxubGV0IHN0YXRlID0gU3RhdGUuZGVzZXJpYWxpemVTdGF0ZSgpO1xuXG4vLyBGaWx0ZXIgb3V0IGlucHV0cyB0aGF0IGFyZSBoaWRkZW4uXG5zdGF0ZS5nZXRIaWRkZW5Qcm9wcygpLmZvckVhY2gocHJvcCA9PiB7XG4gIGlmIChwcm9wIGluIElOUFVUUykge1xuICAgIGRlbGV0ZSBJTlBVVFNbcHJvcF07XG4gIH1cbn0pO1xuXG5sZXQgYm91bmRhcnk6IHtbaWQ6IHN0cmluZ106IG51bWJlcltdW119ID0ge307XG5sZXQgc2VsZWN0ZWROb2RlSWQ6IHN0cmluZyA9IG51bGw7XG4vLyBQbG90IHRoZSBoZWF0bWFwLlxubGV0IHhEb21haW46IFtudW1iZXIsIG51bWJlcl0gPSBbLTYsIDZdO1xubGV0IGhlYXRNYXAgPVxuICAgIG5ldyBIZWF0TWFwKDMwMCwgREVOU0lUWSwgeERvbWFpbiwgeERvbWFpbiwgZDMuc2VsZWN0KFwiI2hlYXRtYXBcIiksXG4gICAgICAgIHtzaG93QXhlczogdHJ1ZX0pO1xubGV0IGxpbmtXaWR0aFNjYWxlID0gZDMuc2NhbGUubGluZWFyKClcbiAgLmRvbWFpbihbMCwgNV0pXG4gIC5yYW5nZShbMSwgMTBdKVxuICAuY2xhbXAodHJ1ZSk7XG5sZXQgY29sb3JTY2FsZSA9IGQzLnNjYWxlLmxpbmVhcjxzdHJpbmc+KClcbiAgICAgICAgICAgICAgICAgICAgIC5kb21haW4oWy0xLCAwLCAxXSlcbiAgICAgICAgICAgICAgICAgICAgIC5yYW5nZShbXCIjZjU5MzIyXCIsIFwiI2U4ZWFlYlwiLCBcIiMwODc3YmRcIl0pXG4gICAgICAgICAgICAgICAgICAgICAuY2xhbXAodHJ1ZSk7XG5sZXQgaXRlciA9IDA7XG5sZXQgdHJhaW5EYXRhOiBFeGFtcGxlMkRbXSA9IFtdO1xubGV0IHRlc3REYXRhOiBFeGFtcGxlMkRbXSA9IFtdO1xubGV0IG5ldHdvcms6IG5uLk5vZGVbXVtdID0gbnVsbDtcbmxldCBsb3NzVHJhaW4gPSAwO1xubGV0IGxvc3NUZXN0ID0gMDtcbmxldCBwbGF5ZXIgPSBuZXcgUGxheWVyKCk7XG5sZXQgbGluZUNoYXJ0ID0gbmV3IEFwcGVuZGluZ0xpbmVDaGFydChkMy5zZWxlY3QoXCIjbGluZWNoYXJ0XCIpLFxuICAgIFtcIiM3NzdcIiwgXCJibGFja1wiXSk7XG5cbmZ1bmN0aW9uIG1ha2VHVUkoKSB7XG4gIGQzLnNlbGVjdChcIiNyZXNldC1idXR0b25cIikub24oXCJjbGlja1wiLCAoKSA9PiB7XG4gICAgcmVzZXQoKTtcbiAgICBkMy5zZWxlY3QoXCIjcGxheS1wYXVzZS1idXR0b25cIik7XG4gIH0pO1xuXG4gIGQzLnNlbGVjdChcIiNwbGF5LXBhdXNlLWJ1dHRvblwiKS5vbihcImNsaWNrXCIsIGZ1bmN0aW9uICgpIHtcbiAgICAvLyBDaGFuZ2UgdGhlIGJ1dHRvbidzIGNvbnRlbnQuXG4gICAgcGxheWVyLnBsYXlPclBhdXNlKCk7XG4gIH0pO1xuXG4gIHBsYXllci5vblBsYXlQYXVzZShpc1BsYXlpbmcgPT4ge1xuICAgIGQzLnNlbGVjdChcIiNwbGF5LXBhdXNlLWJ1dHRvblwiKS5jbGFzc2VkKFwicGxheWluZ1wiLCBpc1BsYXlpbmcpO1xuICB9KTtcblxuICBkMy5zZWxlY3QoXCIjbmV4dC1zdGVwLWJ1dHRvblwiKS5vbihcImNsaWNrXCIsICgpID0+IHtcbiAgICBwbGF5ZXIucGF1c2UoKTtcbiAgICBvbmVTdGVwKCk7XG4gIH0pO1xuXG4gIGQzLnNlbGVjdChcIiNkYXRhLXJlZ2VuLWJ1dHRvblwiKS5vbihcImNsaWNrXCIsICgpID0+IHtcbiAgICBnZW5lcmF0ZURhdGEoKTtcbiAgfSk7XG5cbiAgbGV0IGRhdGFUaHVtYm5haWxzID0gZDMuc2VsZWN0QWxsKFwiY2FudmFzW2RhdGEtZGF0YXNldF1cIik7XG4gIGRhdGFUaHVtYm5haWxzLm9uKFwiY2xpY2tcIiwgZnVuY3Rpb24oKSB7XG4gICAgbGV0IG5ld0RhdGFzZXQgPSBkYXRhc2V0c1t0aGlzLmRhdGFzZXQuZGF0YXNldF07XG4gICAgaWYgKG5ld0RhdGFzZXQgPT09IHN0YXRlLmRhdGFzZXQpIHtcbiAgICAgIHJldHVybjsgLy8gTm8tb3AuXG4gICAgfVxuICAgIHN0YXRlLmRhdGFzZXQgPSAgbmV3RGF0YXNldDtcbiAgICBkYXRhVGh1bWJuYWlscy5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgZmFsc2UpO1xuICAgIGQzLnNlbGVjdCh0aGlzKS5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgdHJ1ZSk7XG4gICAgZ2VuZXJhdGVEYXRhKCk7XG4gICAgcmVzZXQoKTtcbiAgfSk7XG5cbiAgbGV0IGRhdGFzZXRLZXkgPSBnZXRLZXlGcm9tVmFsdWUoZGF0YXNldHMsIHN0YXRlLmRhdGFzZXQpO1xuICAvLyBTZWxlY3QgdGhlIGRhdGFzZXQgYWNjb3JkaW5nIHRvIHRoZSBjdXJyZW50IHN0YXRlLlxuICBkMy5zZWxlY3QoYGNhbnZhc1tkYXRhLWRhdGFzZXQ9JHtkYXRhc2V0S2V5fV1gKVxuICAgIC5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgdHJ1ZSk7XG5cbiAgbGV0IHJlZ0RhdGFUaHVtYm5haWxzID0gZDMuc2VsZWN0QWxsKFwiY2FudmFzW2RhdGEtcmVnRGF0YXNldF1cIik7XG4gIHJlZ0RhdGFUaHVtYm5haWxzLm9uKFwiY2xpY2tcIiwgZnVuY3Rpb24oKSB7XG4gICAgbGV0IG5ld0RhdGFzZXQgPSByZWdEYXRhc2V0c1t0aGlzLmRhdGFzZXQucmVnZGF0YXNldF07XG4gICAgaWYgKG5ld0RhdGFzZXQgPT09IHN0YXRlLnJlZ0RhdGFzZXQpIHtcbiAgICAgIHJldHVybjsgLy8gTm8tb3AuXG4gICAgfVxuICAgIHN0YXRlLnJlZ0RhdGFzZXQgPSAgbmV3RGF0YXNldDtcbiAgICByZWdEYXRhVGh1bWJuYWlscy5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgZmFsc2UpO1xuICAgIGQzLnNlbGVjdCh0aGlzKS5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgdHJ1ZSk7XG4gICAgZ2VuZXJhdGVEYXRhKCk7XG4gICAgcmVzZXQoKTtcbiAgfSk7XG5cbiAgbGV0IHJlZ0RhdGFzZXRLZXkgPSBnZXRLZXlGcm9tVmFsdWUocmVnRGF0YXNldHMsIHN0YXRlLnJlZ0RhdGFzZXQpO1xuICAvLyBTZWxlY3QgdGhlIGRhdGFzZXQgYWNjb3JkaW5nIHRvIHRoZSBjdXJyZW50IHN0YXRlLlxuICBkMy5zZWxlY3QoYGNhbnZhc1tkYXRhLXJlZ0RhdGFzZXQ9JHtyZWdEYXRhc2V0S2V5fV1gKVxuICAgIC5jbGFzc2VkKFwic2VsZWN0ZWRcIiwgdHJ1ZSk7XG5cbiAgZDMuc2VsZWN0KFwiI2FkZC1sYXllcnNcIikub24oXCJjbGlja1wiLCAoKSA9PiB7XG4gICAgaWYgKHN0YXRlLm51bUhpZGRlbkxheWVycyA+PSA2KSB7XG4gICAgICByZXR1cm47XG4gICAgfVxuICAgIHN0YXRlLm5ldHdvcmtTaGFwZVtzdGF0ZS5udW1IaWRkZW5MYXllcnNdID0gMjtcbiAgICBzdGF0ZS5udW1IaWRkZW5MYXllcnMrKztcbiAgICByZXNldCgpO1xuICB9KTtcblxuICBkMy5zZWxlY3QoXCIjcmVtb3ZlLWxheWVyc1wiKS5vbihcImNsaWNrXCIsICgpID0+IHtcbiAgICBpZiAoc3RhdGUubnVtSGlkZGVuTGF5ZXJzIDw9IDApIHtcbiAgICAgIHJldHVybjtcbiAgICB9XG4gICAgc3RhdGUubnVtSGlkZGVuTGF5ZXJzLS07XG4gICAgc3RhdGUubmV0d29ya1NoYXBlLnNwbGljZShzdGF0ZS5udW1IaWRkZW5MYXllcnMpO1xuICAgIHJlc2V0KCk7XG4gIH0pO1xuXG4gIGxldCBzaG93VGVzdERhdGEgPSBkMy5zZWxlY3QoXCIjc2hvdy10ZXN0LWRhdGFcIikub24oXCJjaGFuZ2VcIiwgZnVuY3Rpb24oKSB7XG4gICAgc3RhdGUuc2hvd1Rlc3REYXRhID0gdGhpcy5jaGVja2VkO1xuICAgIHN0YXRlLnNlcmlhbGl6ZSgpO1xuICAgIGhlYXRNYXAudXBkYXRlVGVzdFBvaW50cyhzdGF0ZS5zaG93VGVzdERhdGEgPyB0ZXN0RGF0YSA6IFtdKTtcbiAgfSk7XG4gIC8vIENoZWNrL3VuY2hlY2sgdGhlIGNoZWNrYm94IGFjY29yZGluZyB0byB0aGUgY3VycmVudCBzdGF0ZS5cbiAgc2hvd1Rlc3REYXRhLnByb3BlcnR5KFwiY2hlY2tlZFwiLCBzdGF0ZS5zaG93VGVzdERhdGEpO1xuXG4gIGxldCBkaXNjcmV0aXplID0gZDMuc2VsZWN0KFwiI2Rpc2NyZXRpemVcIikub24oXCJjaGFuZ2VcIiwgZnVuY3Rpb24oKSB7XG4gICAgc3RhdGUuZGlzY3JldGl6ZSA9IHRoaXMuY2hlY2tlZDtcbiAgICBzdGF0ZS5zZXJpYWxpemUoKTtcbiAgICB1cGRhdGVVSSgpO1xuICB9KTtcbiAgLy8gQ2hlY2svdW5jaGVjayB0aGUgY2hlY2JveCBhY2NvcmRpbmcgdG8gdGhlIGN1cnJlbnQgc3RhdGUuXG4gIGRpc2NyZXRpemUucHJvcGVydHkoXCJjaGVja2VkXCIsIHN0YXRlLmRpc2NyZXRpemUpO1xuXG4gIGxldCBwZXJjVHJhaW4gPSBkMy5zZWxlY3QoXCIjcGVyY1RyYWluRGF0YVwiKS5vbihcImlucHV0XCIsIGZ1bmN0aW9uKCkge1xuICAgIHN0YXRlLnBlcmNUcmFpbkRhdGEgPSB0aGlzLnZhbHVlO1xuICAgIGQzLnNlbGVjdChcImxhYmVsW2Zvcj0ncGVyY1RyYWluRGF0YSddIC52YWx1ZVwiKS50ZXh0KHRoaXMudmFsdWUpO1xuICAgIGdlbmVyYXRlRGF0YSgpO1xuICAgIHJlc2V0KCk7XG4gIH0pO1xuICBwZXJjVHJhaW4ucHJvcGVydHkoXCJ2YWx1ZVwiLCBzdGF0ZS5wZXJjVHJhaW5EYXRhKTtcbiAgZDMuc2VsZWN0KFwibGFiZWxbZm9yPSdwZXJjVHJhaW5EYXRhJ10gLnZhbHVlXCIpLnRleHQoc3RhdGUucGVyY1RyYWluRGF0YSk7XG5cbiAgbGV0IG5vaXNlID0gZDMuc2VsZWN0KFwiI25vaXNlXCIpLm9uKFwiaW5wdXRcIiwgZnVuY3Rpb24oKSB7XG4gICAgc3RhdGUubm9pc2UgPSB0aGlzLnZhbHVlO1xuICAgIGQzLnNlbGVjdChcImxhYmVsW2Zvcj0nbm9pc2UnXSAudmFsdWVcIikudGV4dCh0aGlzLnZhbHVlKTtcbiAgICBnZW5lcmF0ZURhdGEoKTtcbiAgICByZXNldCgpO1xuICB9KTtcbiAgbm9pc2UucHJvcGVydHkoXCJ2YWx1ZVwiLCBzdGF0ZS5ub2lzZSk7XG4gIGQzLnNlbGVjdChcImxhYmVsW2Zvcj0nbm9pc2UnXSAudmFsdWVcIikudGV4dChzdGF0ZS5ub2lzZSk7XG5cbiAgbGV0IGJhdGNoU2l6ZSA9IGQzLnNlbGVjdChcIiNiYXRjaFNpemVcIikub24oXCJpbnB1dFwiLCBmdW5jdGlvbigpIHtcbiAgICBzdGF0ZS5iYXRjaFNpemUgPSB0aGlzLnZhbHVlO1xuICAgIGQzLnNlbGVjdChcImxhYmVsW2Zvcj0nYmF0Y2hTaXplJ10gLnZhbHVlXCIpLnRleHQodGhpcy52YWx1ZSk7XG4gICAgcmVzZXQoKTtcbiAgfSk7XG4gIGJhdGNoU2l6ZS5wcm9wZXJ0eShcInZhbHVlXCIsIHN0YXRlLmJhdGNoU2l6ZSk7XG4gIGQzLnNlbGVjdChcImxhYmVsW2Zvcj0nYmF0Y2hTaXplJ10gLnZhbHVlXCIpLnRleHQoc3RhdGUuYmF0Y2hTaXplKTtcblxuICBsZXQgYWN0aXZhdGlvbkRyb3Bkb3duID0gZDMuc2VsZWN0KFwiI2FjdGl2YXRpb25zXCIpLm9uKFwiY2hhbmdlXCIsIGZ1bmN0aW9uKCkge1xuICAgIHN0YXRlLmFjdGl2YXRpb24gPSBhY3RpdmF0aW9uc1t0aGlzLnZhbHVlXTtcbiAgICB1cGRhdGVBY3RpdmF0aW9uKCk7XG4gIH0pO1xuICBhY3RpdmF0aW9uRHJvcGRvd24ucHJvcGVydHkoXCJ2YWx1ZVwiLFxuICAgICAgZ2V0S2V5RnJvbVZhbHVlKGFjdGl2YXRpb25zLCBzdGF0ZS5hY3RpdmF0aW9uKSk7XG5cbiAgbGV0IGxlYXJuaW5nUmF0ZSA9IGQzLnNlbGVjdChcIiNsZWFybmluZ1JhdGVcIikub24oXCJjaGFuZ2VcIiwgZnVuY3Rpb24oKSB7XG4gICAgc3RhdGUubGVhcm5pbmdSYXRlID0gK3RoaXMudmFsdWU7XG4gIH0pO1xuICBsZWFybmluZ1JhdGUucHJvcGVydHkoXCJ2YWx1ZVwiLCBzdGF0ZS5sZWFybmluZ1JhdGUpO1xuXG4gIGxldCByZWd1bGFyRHJvcGRvd24gPSBkMy5zZWxlY3QoXCIjcmVndWxhcml6YXRpb25zXCIpLm9uKFwiY2hhbmdlXCIsXG4gICAgICBmdW5jdGlvbigpIHtcbiAgICBzdGF0ZS5yZWd1bGFyaXphdGlvbiA9IHJlZ3VsYXJpemF0aW9uc1t0aGlzLnZhbHVlXTtcbiAgICByZXNldCgpO1xuICB9KTtcbiAgcmVndWxhckRyb3Bkb3duLnByb3BlcnR5KFwidmFsdWVcIixcbiAgICAgIGdldEtleUZyb21WYWx1ZShyZWd1bGFyaXphdGlvbnMsIHN0YXRlLnJlZ3VsYXJpemF0aW9uKSk7XG5cbiAgbGV0IHJlZ3VsYXJSYXRlID0gZDMuc2VsZWN0KFwiI3JlZ3VsYXJSYXRlXCIpLm9uKFwiY2hhbmdlXCIsIGZ1bmN0aW9uKCkge1xuICAgIHN0YXRlLnJlZ3VsYXJpemF0aW9uUmF0ZSA9ICt0aGlzLnZhbHVlO1xuICAgIHJlc2V0KCk7XG4gIH0pO1xuICByZWd1bGFyUmF0ZS5wcm9wZXJ0eShcInZhbHVlXCIsIHN0YXRlLnJlZ3VsYXJpemF0aW9uUmF0ZSk7XG5cbiAgbGV0IHByb2JsZW0gPSBkMy5zZWxlY3QoXCIjcHJvYmxlbVwiKS5vbihcImNoYW5nZVwiLCBmdW5jdGlvbigpIHtcbiAgICBzdGF0ZS5wcm9ibGVtID0gcHJvYmxlbXNbdGhpcy52YWx1ZV07XG4gICAgZ2VuZXJhdGVEYXRhKCk7XG4gICAgZHJhd0RhdGFzZXRUaHVtYm5haWxzKCk7XG4gICAgcmVzZXQoKTtcbiAgfSk7XG4gIHByb2JsZW0ucHJvcGVydHkoXCJ2YWx1ZVwiLCBnZXRLZXlGcm9tVmFsdWUocHJvYmxlbXMsIHN0YXRlLnByb2JsZW0pKTtcblxuICAvLyBBZGQgc2NhbGUgdG8gdGhlIGdyYWRpZW50IGNvbG9yIG1hcC5cbiAgbGV0IHggPSBkMy5zY2FsZS5saW5lYXIoKS5kb21haW4oWy0xLCAxXSkucmFuZ2UoWzAsIDE0NF0pO1xuICBsZXQgeEF4aXMgPSBkMy5zdmcuYXhpcygpXG4gICAgLnNjYWxlKHgpXG4gICAgLm9yaWVudChcImJvdHRvbVwiKVxuICAgIC50aWNrVmFsdWVzKFstMSwgMCwgMV0pXG4gICAgLnRpY2tGb3JtYXQoZDMuZm9ybWF0KFwiZFwiKSk7XG4gIGQzLnNlbGVjdChcIiNjb2xvcm1hcCBnLmNvcmVcIikuYXBwZW5kKFwiZ1wiKVxuICAgIC5hdHRyKFwiY2xhc3NcIiwgXCJ4IGF4aXNcIilcbiAgICAuYXR0cihcInRyYW5zZm9ybVwiLCBcInRyYW5zbGF0ZSgwLDEwKVwiKVxuICAgIC5jYWxsKHhBeGlzKTtcblxuICAvLyBMaXN0ZW4gZm9yIGNzcy1yZXNwb25zaXZlIGNoYW5nZXMgYW5kIHJlZHJhdyB0aGUgc3ZnIG5ldHdvcmsuXG5cbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoXCJyZXNpemVcIiwgKCkgPT4ge1xuICAgIGxldCBuZXdXaWR0aCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoXCIjbWFpbi1wYXJ0XCIpXG4gICAgICAgIC5nZXRCb3VuZGluZ0NsaWVudFJlY3QoKS53aWR0aDtcbiAgICBpZiAobmV3V2lkdGggIT09IG1haW5XaWR0aCkge1xuICAgICAgbWFpbldpZHRoID0gbmV3V2lkdGg7XG4gICAgICBkcmF3TmV0d29yayhuZXR3b3JrKTtcbiAgICAgIHVwZGF0ZVVJKHRydWUpO1xuICAgIH1cbiAgfSk7XG59XG5cbmZ1bmN0aW9uIHVwZGF0ZUJpYXNlc1VJKG5ldHdvcms6IG5uLk5vZGVbXVtdKSB7XG4gIG5uLmZvckVhY2hOb2RlKG5ldHdvcmssIHRydWUsIG5vZGUgPT4ge1xuICAgIGQzLnNlbGVjdChgcmVjdCNiaWFzLSR7bm9kZS5pZH1gKS5zdHlsZShcImZpbGxcIiwgY29sb3JTY2FsZShub2RlLmJpYXMpKTtcbiAgfSk7XG59XG5cbmZ1bmN0aW9uIHVwZGF0ZVdlaWdodHNVSShuZXR3b3JrOiBubi5Ob2RlW11bXSwgY29udGFpbmVyOiBkMy5TZWxlY3Rpb248YW55Pikge1xuICBmb3IgKGxldCBsYXllcklkeCA9IDE7IGxheWVySWR4IDwgbmV0d29yay5sZW5ndGg7IGxheWVySWR4KyspIHtcbiAgICBsZXQgY3VycmVudExheWVyID0gbmV0d29ya1tsYXllcklkeF07XG4gICAgLy8gVXBkYXRlIGFsbCB0aGUgbm9kZXMgaW4gdGhpcyBsYXllci5cbiAgICBmb3IgKGxldCBpID0gMDsgaSA8IGN1cnJlbnRMYXllci5sZW5ndGg7IGkrKykge1xuICAgICAgbGV0IG5vZGUgPSBjdXJyZW50TGF5ZXJbaV07XG4gICAgICBmb3IgKGxldCBqID0gMDsgaiA8IG5vZGUuaW5wdXRMaW5rcy5sZW5ndGg7IGorKykge1xuICAgICAgICBsZXQgbGluayA9IG5vZGUuaW5wdXRMaW5rc1tqXTtcbiAgICAgICAgY29udGFpbmVyLnNlbGVjdChgI2xpbmske2xpbmsuc291cmNlLmlkfS0ke2xpbmsuZGVzdC5pZH1gKVxuICAgICAgICAgICAgLnN0eWxlKHtcbiAgICAgICAgICAgICAgXCJzdHJva2UtZGFzaG9mZnNldFwiOiAtaXRlciAvIDMsXG4gICAgICAgICAgICAgIFwic3Ryb2tlLXdpZHRoXCI6IGxpbmtXaWR0aFNjYWxlKE1hdGguYWJzKGxpbmsud2VpZ2h0KSksXG4gICAgICAgICAgICAgIFwic3Ryb2tlXCI6IGNvbG9yU2NhbGUobGluay53ZWlnaHQpXG4gICAgICAgICAgICB9KVxuICAgICAgICAgICAgLmRhdHVtKGxpbmspO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG5mdW5jdGlvbiBkcmF3Tm9kZShjeDogbnVtYmVyLCBjeTogbnVtYmVyLCBub2RlSWQ6IHN0cmluZywgaXNJbnB1dDogYm9vbGVhbixcbiAgICBjb250YWluZXI6IGQzLlNlbGVjdGlvbjxhbnk+LCBub2RlPzogbm4uTm9kZSkge1xuICBsZXQgeCA9IGN4IC0gUkVDVF9TSVpFIC8gMjtcbiAgbGV0IHkgPSBjeSAtIFJFQ1RfU0laRSAvIDI7XG5cbiAgbGV0IG5vZGVHcm91cCA9IGNvbnRhaW5lci5hcHBlbmQoXCJnXCIpXG4gICAgLmF0dHIoe1xuICAgICAgXCJjbGFzc1wiOiBcIm5vZGVcIixcbiAgICAgIFwiaWRcIjogYG5vZGUke25vZGVJZH1gLFxuICAgICAgXCJ0cmFuc2Zvcm1cIjogYHRyYW5zbGF0ZSgke3h9LCR7eX0pYFxuICAgIH0pO1xuXG4gIC8vIERyYXcgdGhlIG1haW4gcmVjdGFuZ2xlLlxuICBub2RlR3JvdXAuYXBwZW5kKFwicmVjdFwiKVxuICAgIC5hdHRyKHtcbiAgICAgIHg6IDAsXG4gICAgICB5OiAwLFxuICAgICAgd2lkdGg6IFJFQ1RfU0laRSxcbiAgICAgIGhlaWdodDogUkVDVF9TSVpFLFxuICAgIH0pO1xuICBsZXQgYWN0aXZlT3JOb3RDbGFzcyA9IHN0YXRlW25vZGVJZF0gPyBcImFjdGl2ZVwiIDogXCJpbmFjdGl2ZVwiO1xuICBpZiAoaXNJbnB1dCkge1xuICAgIGxldCBsYWJlbCA9IElOUFVUU1tub2RlSWRdLmxhYmVsICE9IG51bGwgP1xuICAgICAgICBJTlBVVFNbbm9kZUlkXS5sYWJlbCA6IG5vZGVJZDtcbiAgICAvLyBEcmF3IHRoZSBpbnB1dCBsYWJlbC5cbiAgICBsZXQgdGV4dCA9IG5vZGVHcm91cC5hcHBlbmQoXCJ0ZXh0XCIpLmF0dHIoe1xuICAgICAgY2xhc3M6IFwibWFpbi1sYWJlbFwiLFxuICAgICAgeDogLTEwLFxuICAgICAgeTogUkVDVF9TSVpFIC8gMiwgXCJ0ZXh0LWFuY2hvclwiOiBcImVuZFwiXG4gICAgfSk7XG4gICAgaWYgKC9bX15dLy50ZXN0KGxhYmVsKSkge1xuICAgICAgbGV0IG15UmUgPSAvKC4qPykoW19eXSkoLikvZztcbiAgICAgIGxldCBteUFycmF5O1xuICAgICAgbGV0IGxhc3RJbmRleDtcbiAgICAgIHdoaWxlICgobXlBcnJheSA9IG15UmUuZXhlYyhsYWJlbCkpICE9PSBudWxsKSB7XG4gICAgICAgIGxhc3RJbmRleCA9IG15UmUubGFzdEluZGV4O1xuICAgICAgICBsZXQgcHJlZml4ID0gbXlBcnJheVsxXTtcbiAgICAgICAgbGV0IHNlcCA9IG15QXJyYXlbMl07XG4gICAgICAgIGxldCBzdWZmaXggPSBteUFycmF5WzNdO1xuICAgICAgICBpZiAocHJlZml4KSB7XG4gICAgICAgICAgdGV4dC5hcHBlbmQoXCJ0c3BhblwiKS50ZXh0KHByZWZpeCk7XG4gICAgICAgIH1cbiAgICAgICAgdGV4dC5hcHBlbmQoXCJ0c3BhblwiKVxuICAgICAgICAuYXR0cihcImJhc2VsaW5lLXNoaWZ0XCIsIHNlcCA9PSBcIl9cIiA/IFwic3ViXCIgOiBcInN1cGVyXCIpXG4gICAgICAgIC5zdHlsZShcImZvbnQtc2l6ZVwiLCBcIjlweFwiKVxuICAgICAgICAudGV4dChzdWZmaXgpO1xuICAgICAgfVxuICAgICAgaWYgKGxhYmVsLnN1YnN0cmluZyhsYXN0SW5kZXgpKSB7XG4gICAgICAgIHRleHQuYXBwZW5kKFwidHNwYW5cIikudGV4dChsYWJlbC5zdWJzdHJpbmcobGFzdEluZGV4KSk7XG4gICAgICB9XG4gICAgfSBlbHNlIHtcbiAgICAgIHRleHQuYXBwZW5kKFwidHNwYW5cIikudGV4dChsYWJlbCk7XG4gICAgfVxuICAgIG5vZGVHcm91cC5jbGFzc2VkKGFjdGl2ZU9yTm90Q2xhc3MsIHRydWUpO1xuICB9XG4gIGlmICghaXNJbnB1dCkge1xuICAgIC8vIERyYXcgdGhlIG5vZGUncyBiaWFzLlxuICAgIG5vZGVHcm91cC5hcHBlbmQoXCJyZWN0XCIpXG4gICAgICAuYXR0cih7XG4gICAgICAgIGlkOiBgYmlhcy0ke25vZGVJZH1gLFxuICAgICAgICB4OiAtQklBU19TSVpFIC0gMixcbiAgICAgICAgeTogUkVDVF9TSVpFIC0gQklBU19TSVpFICsgMyxcbiAgICAgICAgd2lkdGg6IEJJQVNfU0laRSxcbiAgICAgICAgaGVpZ2h0OiBCSUFTX1NJWkUsXG4gICAgICB9KS5vbihcIm1vdXNlZW50ZXJcIiwgZnVuY3Rpb24oKSB7XG4gICAgICAgIHVwZGF0ZUhvdmVyQ2FyZChIb3ZlclR5cGUuQklBUywgbm9kZSwgZDMubW91c2UoY29udGFpbmVyLm5vZGUoKSkpO1xuICAgICAgfSkub24oXCJtb3VzZWxlYXZlXCIsIGZ1bmN0aW9uKCkge1xuICAgICAgICB1cGRhdGVIb3ZlckNhcmQobnVsbCk7XG4gICAgICB9KTtcbiAgfVxuXG4gIC8vIERyYXcgdGhlIG5vZGUncyBjYW52YXMuXG4gIGxldCBkaXYgPSBkMy5zZWxlY3QoXCIjbmV0d29ya1wiKS5pbnNlcnQoXCJkaXZcIiwgXCI6Zmlyc3QtY2hpbGRcIilcbiAgICAuYXR0cih7XG4gICAgICBcImlkXCI6IGBjYW52YXMtJHtub2RlSWR9YCxcbiAgICAgIFwiY2xhc3NcIjogXCJjYW52YXNcIlxuICAgIH0pXG4gICAgLnN0eWxlKHtcbiAgICAgIHBvc2l0aW9uOiBcImFic29sdXRlXCIsXG4gICAgICBsZWZ0OiBgJHt4ICsgM31weGAsXG4gICAgICB0b3A6IGAke3kgKyAzfXB4YFxuICAgIH0pXG4gICAgLm9uKFwibW91c2VlbnRlclwiLCBmdW5jdGlvbigpIHtcbiAgICAgIHNlbGVjdGVkTm9kZUlkID0gbm9kZUlkO1xuICAgICAgZGl2LmNsYXNzZWQoXCJob3ZlcmVkXCIsIHRydWUpO1xuICAgICAgbm9kZUdyb3VwLmNsYXNzZWQoXCJob3ZlcmVkXCIsIHRydWUpO1xuICAgICAgdXBkYXRlRGVjaXNpb25Cb3VuZGFyeShuZXR3b3JrLCBmYWxzZSk7XG4gICAgICBoZWF0TWFwLnVwZGF0ZUJhY2tncm91bmQoYm91bmRhcnlbbm9kZUlkXSwgc3RhdGUuZGlzY3JldGl6ZSk7XG4gICAgfSlcbiAgICAub24oXCJtb3VzZWxlYXZlXCIsIGZ1bmN0aW9uKCkge1xuICAgICAgc2VsZWN0ZWROb2RlSWQgPSBudWxsO1xuICAgICAgZGl2LmNsYXNzZWQoXCJob3ZlcmVkXCIsIGZhbHNlKTtcbiAgICAgIG5vZGVHcm91cC5jbGFzc2VkKFwiaG92ZXJlZFwiLCBmYWxzZSk7XG4gICAgICB1cGRhdGVEZWNpc2lvbkJvdW5kYXJ5KG5ldHdvcmssIGZhbHNlKTtcbiAgICAgIGhlYXRNYXAudXBkYXRlQmFja2dyb3VuZChib3VuZGFyeVtubi5nZXRPdXRwdXROb2RlKG5ldHdvcmspLmlkXSxcbiAgICAgICAgICBzdGF0ZS5kaXNjcmV0aXplKTtcbiAgICB9KTtcbiAgaWYgKGlzSW5wdXQpIHtcbiAgICBkaXYub24oXCJjbGlja1wiLCBmdW5jdGlvbigpIHtcbiAgICAgIHN0YXRlW25vZGVJZF0gPSAhc3RhdGVbbm9kZUlkXTtcbiAgICAgIHJlc2V0KCk7XG4gICAgfSk7XG4gICAgZGl2LnN0eWxlKFwiY3Vyc29yXCIsIFwicG9pbnRlclwiKTtcbiAgfVxuICBpZiAoaXNJbnB1dCkge1xuICAgIGRpdi5jbGFzc2VkKGFjdGl2ZU9yTm90Q2xhc3MsIHRydWUpO1xuICB9XG4gIGxldCBub2RlSGVhdE1hcCA9IG5ldyBIZWF0TWFwKFJFQ1RfU0laRSwgREVOU0lUWSAvIDEwLCB4RG9tYWluLFxuICAgICAgeERvbWFpbiwgZGl2LCB7bm9Tdmc6IHRydWV9KTtcbiAgZGl2LmRhdHVtKHtoZWF0bWFwOiBub2RlSGVhdE1hcCwgaWQ6IG5vZGVJZH0pO1xuXG59XG5cbi8vIERyYXcgbmV0d29ya1xuZnVuY3Rpb24gZHJhd05ldHdvcmsobmV0d29yazogbm4uTm9kZVtdW10pOiB2b2lkIHtcbiAgbGV0IHN2ZyA9IGQzLnNlbGVjdChcIiNzdmdcIik7XG4gIC8vIFJlbW92ZSBhbGwgc3ZnIGVsZW1lbnRzLlxuICBzdmcuc2VsZWN0KFwiZy5jb3JlXCIpLnJlbW92ZSgpO1xuICAvLyBSZW1vdmUgYWxsIGRpdiBlbGVtZW50cy5cbiAgZDMuc2VsZWN0KFwiI25ldHdvcmtcIikuc2VsZWN0QWxsKFwiZGl2LmNhbnZhc1wiKS5yZW1vdmUoKTtcbiAgZDMuc2VsZWN0KFwiI25ldHdvcmtcIikuc2VsZWN0QWxsKFwiZGl2LnBsdXMtbWludXMtbmV1cm9uc1wiKS5yZW1vdmUoKTtcblxuICAvLyBHZXQgdGhlIHdpZHRoIG9mIHRoZSBzdmcgY29udGFpbmVyLlxuICBsZXQgcGFkZGluZyA9IDM7XG4gIGxldCBjbyA9IDxIVE1MRGl2RWxlbWVudD4gZDMuc2VsZWN0KFwiLmNvbHVtbi5vdXRwdXRcIikubm9kZSgpO1xuICBsZXQgY2YgPSA8SFRNTERpdkVsZW1lbnQ+IGQzLnNlbGVjdChcIi5jb2x1bW4uZmVhdHVyZXNcIikubm9kZSgpO1xuICBsZXQgd2lkdGggPSBjby5vZmZzZXRMZWZ0IC0gY2Yub2Zmc2V0TGVmdDtcbiAgc3ZnLmF0dHIoXCJ3aWR0aFwiLCB3aWR0aCk7XG5cbiAgLy8gTWFwIG9mIGFsbCBub2RlIGNvb3JkaW5hdGVzLlxuICBsZXQgbm9kZTJjb29yZDoge1tpZDogc3RyaW5nXToge2N4OiBudW1iZXIsIGN5OiBudW1iZXJ9fSA9IHt9O1xuICBsZXQgY29udGFpbmVyID0gc3ZnLmFwcGVuZChcImdcIilcbiAgICAuY2xhc3NlZChcImNvcmVcIiwgdHJ1ZSlcbiAgICAuYXR0cihcInRyYW5zZm9ybVwiLCBgdHJhbnNsYXRlKCR7cGFkZGluZ30sJHtwYWRkaW5nfSlgKTtcbiAgLy8gRHJhdyB0aGUgbmV0d29yayBsYXllciBieSBsYXllci5cbiAgbGV0IG51bUxheWVycyA9IG5ldHdvcmsubGVuZ3RoO1xuICBsZXQgZmVhdHVyZVdpZHRoID0gMTE4O1xuICBsZXQgbGF5ZXJTY2FsZSA9IGQzLnNjYWxlLm9yZGluYWw8bnVtYmVyLCBudW1iZXI+KClcbiAgICAgIC5kb21haW4oZDMucmFuZ2UoMSwgbnVtTGF5ZXJzIC0gMSkpXG4gICAgICAucmFuZ2VQb2ludHMoW2ZlYXR1cmVXaWR0aCwgd2lkdGggLSBSRUNUX1NJWkVdLCAwLjcpO1xuICBsZXQgbm9kZUluZGV4U2NhbGUgPSAobm9kZUluZGV4OiBudW1iZXIpID0+IG5vZGVJbmRleCAqIChSRUNUX1NJWkUgKyAyNSk7XG5cblxuICBsZXQgY2FsbG91dFRodW1iID0gZDMuc2VsZWN0KFwiLmNhbGxvdXQudGh1bWJuYWlsXCIpLnN0eWxlKFwiZGlzcGxheVwiLCBcIm5vbmVcIik7XG4gIGxldCBjYWxsb3V0V2VpZ2h0cyA9IGQzLnNlbGVjdChcIi5jYWxsb3V0LndlaWdodHNcIikuc3R5bGUoXCJkaXNwbGF5XCIsIFwibm9uZVwiKTtcbiAgbGV0IGlkV2l0aENhbGxvdXQgPSBudWxsO1xuICBsZXQgdGFyZ2V0SWRXaXRoQ2FsbG91dCA9IG51bGw7XG5cbiAgLy8gRHJhdyB0aGUgaW5wdXQgbGF5ZXIgc2VwYXJhdGVseS5cbiAgbGV0IGN4ID0gUkVDVF9TSVpFIC8gMiArIDUwO1xuICBsZXQgbm9kZUlkcyA9IE9iamVjdC5rZXlzKElOUFVUUyk7XG4gIGxldCBtYXhZID0gbm9kZUluZGV4U2NhbGUobm9kZUlkcy5sZW5ndGgpO1xuICBub2RlSWRzLmZvckVhY2goKG5vZGVJZCwgaSkgPT4ge1xuICAgIGxldCBjeSA9IG5vZGVJbmRleFNjYWxlKGkpICsgUkVDVF9TSVpFIC8gMjtcbiAgICBub2RlMmNvb3JkW25vZGVJZF0gPSB7Y3g6IGN4LCBjeTogY3l9O1xuICAgIGRyYXdOb2RlKGN4LCBjeSwgbm9kZUlkLCB0cnVlLCBjb250YWluZXIpO1xuICB9KTtcblxuICAvLyBEcmF3IHRoZSBpbnRlcm1lZGlhdGUgbGF5ZXJzLlxuICBmb3IgKGxldCBsYXllcklkeCA9IDE7IGxheWVySWR4IDwgbnVtTGF5ZXJzIC0gMTsgbGF5ZXJJZHgrKykge1xuICAgIGxldCBudW1Ob2RlcyA9IG5ldHdvcmtbbGF5ZXJJZHhdLmxlbmd0aDtcbiAgICBsZXQgY3ggPSBsYXllclNjYWxlKGxheWVySWR4KSArIFJFQ1RfU0laRSAvIDI7XG4gICAgbWF4WSA9IE1hdGgubWF4KG1heFksIG5vZGVJbmRleFNjYWxlKG51bU5vZGVzKSk7XG4gICAgYWRkUGx1c01pbnVzQ29udHJvbChsYXllclNjYWxlKGxheWVySWR4KSwgbGF5ZXJJZHgpO1xuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgbnVtTm9kZXM7IGkrKykge1xuICAgICAgbGV0IG5vZGUgPSBuZXR3b3JrW2xheWVySWR4XVtpXTtcbiAgICAgIGxldCBjeSA9IG5vZGVJbmRleFNjYWxlKGkpICsgUkVDVF9TSVpFIC8gMjtcbiAgICAgIG5vZGUyY29vcmRbbm9kZS5pZF0gPSB7Y3g6IGN4LCBjeTogY3l9O1xuICAgICAgZHJhd05vZGUoY3gsIGN5LCBub2RlLmlkLCBmYWxzZSwgY29udGFpbmVyLCBub2RlKTtcblxuICAgICAgLy8gU2hvdyBjYWxsb3V0IHRvIHRodW1ibmFpbHMuXG4gICAgICBsZXQgbnVtTm9kZXMgPSBuZXR3b3JrW2xheWVySWR4XS5sZW5ndGg7XG4gICAgICBsZXQgbmV4dE51bU5vZGVzID0gbmV0d29ya1tsYXllcklkeCArIDFdLmxlbmd0aDtcbiAgICAgIGlmIChpZFdpdGhDYWxsb3V0ID09IG51bGwgJiZcbiAgICAgICAgICBpID09PSBudW1Ob2RlcyAtIDEgJiZcbiAgICAgICAgICBuZXh0TnVtTm9kZXMgPD0gbnVtTm9kZXMpIHtcbiAgICAgICAgY2FsbG91dFRodW1iLnN0eWxlKHtcbiAgICAgICAgICBkaXNwbGF5OiBudWxsLFxuICAgICAgICAgIHRvcDogYCR7MjAgKyAzICsgY3l9cHhgLFxuICAgICAgICAgIGxlZnQ6IGAke2N4fXB4YFxuICAgICAgICB9KTtcbiAgICAgICAgaWRXaXRoQ2FsbG91dCA9IG5vZGUuaWQ7XG4gICAgICB9XG5cbiAgICAgIC8vIERyYXcgbGlua3MuXG4gICAgICBmb3IgKGxldCBqID0gMDsgaiA8IG5vZGUuaW5wdXRMaW5rcy5sZW5ndGg7IGorKykge1xuICAgICAgICBsZXQgbGluayA9IG5vZGUuaW5wdXRMaW5rc1tqXTtcbiAgICAgICAgbGV0IHBhdGg6IFNWR1BhdGhFbGVtZW50ID0gPGFueT4gZHJhd0xpbmsobGluaywgbm9kZTJjb29yZCwgbmV0d29yayxcbiAgICAgICAgICAgIGNvbnRhaW5lciwgaiA9PT0gMCwgaiwgbm9kZS5pbnB1dExpbmtzLmxlbmd0aCkubm9kZSgpO1xuICAgICAgICAvLyBTaG93IGNhbGxvdXQgdG8gd2VpZ2h0cy5cbiAgICAgICAgbGV0IHByZXZMYXllciA9IG5ldHdvcmtbbGF5ZXJJZHggLSAxXTtcbiAgICAgICAgbGV0IGxhc3ROb2RlUHJldkxheWVyID0gcHJldkxheWVyW3ByZXZMYXllci5sZW5ndGggLSAxXTtcbiAgICAgICAgaWYgKHRhcmdldElkV2l0aENhbGxvdXQgPT0gbnVsbCAmJlxuICAgICAgICAgICAgaSA9PT0gbnVtTm9kZXMgLSAxICYmXG4gICAgICAgICAgICBsaW5rLnNvdXJjZS5pZCA9PT0gbGFzdE5vZGVQcmV2TGF5ZXIuaWQgJiZcbiAgICAgICAgICAgIChsaW5rLnNvdXJjZS5pZCAhPT0gaWRXaXRoQ2FsbG91dCB8fCBudW1MYXllcnMgPD0gNSkgJiZcbiAgICAgICAgICAgIGxpbmsuZGVzdC5pZCAhPT0gaWRXaXRoQ2FsbG91dCAmJlxuICAgICAgICAgICAgcHJldkxheWVyLmxlbmd0aCA+PSBudW1Ob2Rlcykge1xuICAgICAgICAgIGxldCBtaWRQb2ludCA9IHBhdGguZ2V0UG9pbnRBdExlbmd0aChwYXRoLmdldFRvdGFsTGVuZ3RoKCkgKiAwLjcpO1xuICAgICAgICAgIGNhbGxvdXRXZWlnaHRzLnN0eWxlKHtcbiAgICAgICAgICAgIGRpc3BsYXk6IG51bGwsXG4gICAgICAgICAgICB0b3A6IGAke21pZFBvaW50LnkgKyA1fXB4YCxcbiAgICAgICAgICAgIGxlZnQ6IGAke21pZFBvaW50LnggKyAzfXB4YFxuICAgICAgICAgIH0pO1xuICAgICAgICAgIHRhcmdldElkV2l0aENhbGxvdXQgPSBsaW5rLmRlc3QuaWQ7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAvLyBEcmF3IHRoZSBvdXRwdXQgbm9kZSBzZXBhcmF0ZWx5LlxuICBjeCA9IHdpZHRoICsgUkVDVF9TSVpFIC8gMjtcbiAgbGV0IG5vZGUgPSBuZXR3b3JrW251bUxheWVycyAtIDFdWzBdO1xuICBsZXQgY3kgPSBub2RlSW5kZXhTY2FsZSgwKSArIFJFQ1RfU0laRSAvIDI7XG4gIG5vZGUyY29vcmRbbm9kZS5pZF0gPSB7Y3g6IGN4LCBjeTogY3l9O1xuICAvLyBEcmF3IGxpbmtzLlxuICBmb3IgKGxldCBpID0gMDsgaSA8IG5vZGUuaW5wdXRMaW5rcy5sZW5ndGg7IGkrKykge1xuICAgIGxldCBsaW5rID0gbm9kZS5pbnB1dExpbmtzW2ldO1xuICAgIGRyYXdMaW5rKGxpbmssIG5vZGUyY29vcmQsIG5ldHdvcmssIGNvbnRhaW5lciwgaSA9PT0gMCwgaSxcbiAgICAgICAgbm9kZS5pbnB1dExpbmtzLmxlbmd0aCk7XG4gIH1cbiAgLy8gQWRqdXN0IHRoZSBoZWlnaHQgb2YgdGhlIHN2Zy5cbiAgc3ZnLmF0dHIoXCJoZWlnaHRcIiwgbWF4WSk7XG5cbiAgLy8gQWRqdXN0IHRoZSBoZWlnaHQgb2YgdGhlIGZlYXR1cmVzIGNvbHVtbi5cbiAgbGV0IGhlaWdodCA9IE1hdGgubWF4KFxuICAgIGdldFJlbGF0aXZlSGVpZ2h0KGNhbGxvdXRUaHVtYiksXG4gICAgZ2V0UmVsYXRpdmVIZWlnaHQoY2FsbG91dFdlaWdodHMpLFxuICAgIGdldFJlbGF0aXZlSGVpZ2h0KGQzLnNlbGVjdChcIiNuZXR3b3JrXCIpKVxuICApO1xuICBkMy5zZWxlY3QoXCIuY29sdW1uLmZlYXR1cmVzXCIpLnN0eWxlKFwiaGVpZ2h0XCIsIGhlaWdodCArIFwicHhcIik7XG59XG5cbmZ1bmN0aW9uIGdldFJlbGF0aXZlSGVpZ2h0KHNlbGVjdGlvbjogZDMuU2VsZWN0aW9uPGFueT4pIHtcbiAgbGV0IG5vZGUgPSA8SFRNTEFuY2hvckVsZW1lbnQ+IHNlbGVjdGlvbi5ub2RlKCk7XG4gIHJldHVybiBub2RlLm9mZnNldEhlaWdodCArIG5vZGUub2Zmc2V0VG9wO1xufVxuXG5mdW5jdGlvbiBhZGRQbHVzTWludXNDb250cm9sKHg6IG51bWJlciwgbGF5ZXJJZHg6IG51bWJlcikge1xuICBsZXQgZGl2ID0gZDMuc2VsZWN0KFwiI25ldHdvcmtcIikuYXBwZW5kKFwiZGl2XCIpXG4gICAgLmNsYXNzZWQoXCJwbHVzLW1pbnVzLW5ldXJvbnNcIiwgdHJ1ZSlcbiAgICAuc3R5bGUoXCJsZWZ0XCIsIGAke3ggLSAxMH1weGApO1xuXG4gIGxldCBpID0gbGF5ZXJJZHggLSAxO1xuICBsZXQgZmlyc3RSb3cgPSBkaXYuYXBwZW5kKFwiZGl2XCIpLmF0dHIoXCJjbGFzc1wiLCBgdWktbnVtTm9kZXMke2xheWVySWR4fWApO1xuICBmaXJzdFJvdy5hcHBlbmQoXCJidXR0b25cIilcbiAgICAgIC5hdHRyKFwiY2xhc3NcIiwgXCJtZGwtYnV0dG9uIG1kbC1qcy1idXR0b24gbWRsLWJ1dHRvbi0taWNvblwiKVxuICAgICAgLm9uKFwiY2xpY2tcIiwgKCkgPT4ge1xuICAgICAgICBsZXQgbnVtTmV1cm9ucyA9IHN0YXRlLm5ldHdvcmtTaGFwZVtpXTtcbiAgICAgICAgaWYgKG51bU5ldXJvbnMgPj0gOCkge1xuICAgICAgICAgIHJldHVybjtcbiAgICAgICAgfVxuICAgICAgICBzdGF0ZS5uZXR3b3JrU2hhcGVbaV0rKztcbiAgICAgICAgcmVzZXQoKTtcbiAgICAgIH0pXG4gICAgLmFwcGVuZChcImlcIilcbiAgICAgIC5hdHRyKFwiY2xhc3NcIiwgXCJtYXRlcmlhbC1pY29uc1wiKVxuICAgICAgLnRleHQoXCJhZGRcIik7XG5cbiAgZmlyc3RSb3cuYXBwZW5kKFwiYnV0dG9uXCIpXG4gICAgICAuYXR0cihcImNsYXNzXCIsIFwibWRsLWJ1dHRvbiBtZGwtanMtYnV0dG9uIG1kbC1idXR0b24tLWljb25cIilcbiAgICAgIC5vbihcImNsaWNrXCIsICgpID0+IHtcbiAgICAgICAgbGV0IG51bU5ldXJvbnMgPSBzdGF0ZS5uZXR3b3JrU2hhcGVbaV07XG4gICAgICAgIGlmIChudW1OZXVyb25zIDw9IDEpIHtcbiAgICAgICAgICByZXR1cm47XG4gICAgICAgIH1cbiAgICAgICAgc3RhdGUubmV0d29ya1NoYXBlW2ldLS07XG4gICAgICAgIHJlc2V0KCk7XG4gICAgICB9KVxuICAgIC5hcHBlbmQoXCJpXCIpXG4gICAgICAuYXR0cihcImNsYXNzXCIsIFwibWF0ZXJpYWwtaWNvbnNcIilcbiAgICAgIC50ZXh0KFwicmVtb3ZlXCIpO1xuXG4gIGxldCBzdWZmaXggPSBzdGF0ZS5uZXR3b3JrU2hhcGVbaV0gPiAxID8gXCJzXCIgOiBcIlwiO1xuICBkaXYuYXBwZW5kKFwiZGl2XCIpLnRleHQoXG4gICAgc3RhdGUubmV0d29ya1NoYXBlW2ldICsgXCIgbmV1cm9uXCIgKyBzdWZmaXhcbiAgKTtcbn1cblxuZnVuY3Rpb24gdXBkYXRlSG92ZXJDYXJkKHR5cGU6IEhvdmVyVHlwZSwgbm9kZU9yTGluaz86IG5uLk5vZGUgfCBubi5MaW5rLFxuICAgIGNvb3JkaW5hdGVzPzogW251bWJlciwgbnVtYmVyXSkge1xuICBsZXQgaG92ZXJjYXJkID0gZDMuc2VsZWN0KFwiI2hvdmVyY2FyZFwiKTtcbiAgaWYgKHR5cGUgPT0gbnVsbCkge1xuICAgIGhvdmVyY2FyZC5zdHlsZShcImRpc3BsYXlcIiwgXCJub25lXCIpO1xuICAgIGQzLnNlbGVjdChcIiNzdmdcIikub24oXCJjbGlja1wiLCBudWxsKTtcbiAgICByZXR1cm47XG4gIH1cbiAgZDMuc2VsZWN0KFwiI3N2Z1wiKS5vbihcImNsaWNrXCIsICgpID0+IHtcbiAgICBob3ZlcmNhcmQuc2VsZWN0KFwiLnZhbHVlXCIpLnN0eWxlKFwiZGlzcGxheVwiLCBcIm5vbmVcIik7XG4gICAgbGV0IGlucHV0ID0gaG92ZXJjYXJkLnNlbGVjdChcImlucHV0XCIpO1xuICAgIGlucHV0LnN0eWxlKFwiZGlzcGxheVwiLCBudWxsKTtcbiAgICBpbnB1dC5vbihcImlucHV0XCIsIGZ1bmN0aW9uKCkge1xuICAgICAgaWYgKHRoaXMudmFsdWUgIT0gbnVsbCAmJiB0aGlzLnZhbHVlICE9PSBcIlwiKSB7XG4gICAgICAgIGlmICh0eXBlID09IEhvdmVyVHlwZS5XRUlHSFQpIHtcbiAgICAgICAgICAoPG5uLkxpbms+bm9kZU9yTGluaykud2VpZ2h0ID0gK3RoaXMudmFsdWU7XG4gICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgKDxubi5Ob2RlPm5vZGVPckxpbmspLmJpYXMgPSArdGhpcy52YWx1ZTtcbiAgICAgICAgfVxuICAgICAgICB1cGRhdGVVSSgpO1xuICAgICAgfVxuICAgIH0pO1xuICAgIGlucHV0Lm9uKFwia2V5cHJlc3NcIiwgKCkgPT4ge1xuICAgICAgaWYgKCg8YW55PmQzLmV2ZW50KS5rZXlDb2RlID09IDEzKSB7XG4gICAgICAgIHVwZGF0ZUhvdmVyQ2FyZCh0eXBlLCBub2RlT3JMaW5rLCBjb29yZGluYXRlcyk7XG4gICAgICB9XG4gICAgfSk7XG4gICAgKDxIVE1MSW5wdXRFbGVtZW50PmlucHV0Lm5vZGUoKSkuZm9jdXMoKTtcbiAgfSk7XG4gIGxldCB2YWx1ZSA9IHR5cGUgPT0gSG92ZXJUeXBlLldFSUdIVCA/XG4gICAgKDxubi5MaW5rPm5vZGVPckxpbmspLndlaWdodCA6XG4gICAgKDxubi5Ob2RlPm5vZGVPckxpbmspLmJpYXM7XG4gIGxldCBuYW1lID0gdHlwZSA9PSBIb3ZlclR5cGUuV0VJR0hUID8gXCJXZWlnaHRcIiA6IFwiQmlhc1wiO1xuICBob3ZlcmNhcmQuc3R5bGUoe1xuICAgIFwibGVmdFwiOiBgJHtjb29yZGluYXRlc1swXSArIDIwfXB4YCxcbiAgICBcInRvcFwiOiBgJHtjb29yZGluYXRlc1sxXX1weGAsXG4gICAgXCJkaXNwbGF5XCI6IFwiYmxvY2tcIlxuICB9KTtcbiAgaG92ZXJjYXJkLnNlbGVjdChcIi50eXBlXCIpLnRleHQobmFtZSk7XG4gIGhvdmVyY2FyZC5zZWxlY3QoXCIudmFsdWVcIilcbiAgICAuc3R5bGUoXCJkaXNwbGF5XCIsIG51bGwpXG4gICAgLnRleHQodmFsdWUudG9QcmVjaXNpb24oMikpO1xuICBob3ZlcmNhcmQuc2VsZWN0KFwiaW5wdXRcIilcbiAgICAucHJvcGVydHkoXCJ2YWx1ZVwiLCB2YWx1ZS50b1ByZWNpc2lvbigyKSlcbiAgICAuc3R5bGUoXCJkaXNwbGF5XCIsIFwibm9uZVwiKTtcbn1cblxuZnVuY3Rpb24gZHJhd0xpbmsoXG4gICAgaW5wdXQ6IG5uLkxpbmssIG5vZGUyY29vcmQ6IHtbaWQ6IHN0cmluZ106IHtjeDogbnVtYmVyLCBjeTogbnVtYmVyfX0sXG4gICAgbmV0d29yazogbm4uTm9kZVtdW10sIGNvbnRhaW5lcjogZDMuU2VsZWN0aW9uPGFueT4sXG4gICAgaXNGaXJzdDogYm9vbGVhbiwgaW5kZXg6IG51bWJlciwgbGVuZ3RoOiBudW1iZXIpIHtcbiAgbGV0IGxpbmUgPSBjb250YWluZXIuaW5zZXJ0KFwicGF0aFwiLCBcIjpmaXJzdC1jaGlsZFwiKTtcbiAgbGV0IHNvdXJjZSA9IG5vZGUyY29vcmRbaW5wdXQuc291cmNlLmlkXTtcbiAgbGV0IGRlc3QgPSBub2RlMmNvb3JkW2lucHV0LmRlc3QuaWRdO1xuICBsZXQgZGF0dW0gPSB7XG4gICAgc291cmNlOiB7XG4gICAgICB5OiBzb3VyY2UuY3ggKyBSRUNUX1NJWkUgLyAyICsgMixcbiAgICAgIHg6IHNvdXJjZS5jeVxuICAgIH0sXG4gICAgdGFyZ2V0OiB7XG4gICAgICB5OiBkZXN0LmN4IC0gUkVDVF9TSVpFIC8gMixcbiAgICAgIHg6IGRlc3QuY3kgKyAoKGluZGV4IC0gKGxlbmd0aCAtIDEpIC8gMikgLyBsZW5ndGgpICogMTJcbiAgICB9XG4gIH07XG4gIGxldCBkaWFnb25hbCA9IGQzLnN2Zy5kaWFnb25hbCgpLnByb2plY3Rpb24oZCA9PiBbZC55LCBkLnhdKTtcbiAgbGluZS5hdHRyKHtcbiAgICBcIm1hcmtlci1zdGFydFwiOiBcInVybCgjbWFya2VyQXJyb3cpXCIsXG4gICAgY2xhc3M6IFwibGlua1wiLFxuICAgIGlkOiBcImxpbmtcIiArIGlucHV0LnNvdXJjZS5pZCArIFwiLVwiICsgaW5wdXQuZGVzdC5pZCxcbiAgICBkOiBkaWFnb25hbChkYXR1bSwgMClcbiAgfSk7XG5cbiAgLy8gQWRkIGFuIGludmlzaWJsZSB0aGljayBsaW5rIHRoYXQgd2lsbCBiZSB1c2VkIGZvclxuICAvLyBzaG93aW5nIHRoZSB3ZWlnaHQgdmFsdWUgb24gaG92ZXIuXG4gIGNvbnRhaW5lci5hcHBlbmQoXCJwYXRoXCIpXG4gICAgLmF0dHIoXCJkXCIsIGRpYWdvbmFsKGRhdHVtLCAwKSlcbiAgICAuYXR0cihcImNsYXNzXCIsIFwibGluay1ob3ZlclwiKVxuICAgIC5vbihcIm1vdXNlZW50ZXJcIiwgZnVuY3Rpb24oKSB7XG4gICAgICB1cGRhdGVIb3ZlckNhcmQoSG92ZXJUeXBlLldFSUdIVCwgaW5wdXQsIGQzLm1vdXNlKHRoaXMpKTtcbiAgICB9KS5vbihcIm1vdXNlbGVhdmVcIiwgZnVuY3Rpb24oKSB7XG4gICAgICB1cGRhdGVIb3ZlckNhcmQobnVsbCk7XG4gICAgfSk7XG4gIHJldHVybiBsaW5lO1xufVxuXG4vKipcbiAqIEdpdmVuIGEgbmV1cmFsIG5ldHdvcmssIGl0IGFza3MgdGhlIG5ldHdvcmsgZm9yIHRoZSBvdXRwdXQgKHByZWRpY3Rpb24pXG4gKiBvZiBldmVyeSBub2RlIGluIHRoZSBuZXR3b3JrIHVzaW5nIGlucHV0cyBzYW1wbGVkIG9uIGEgc3F1YXJlIGdyaWQuXG4gKiBJdCByZXR1cm5zIGEgbWFwIHdoZXJlIGVhY2gga2V5IGlzIHRoZSBub2RlIElEIGFuZCB0aGUgdmFsdWUgaXMgYSBzcXVhcmVcbiAqIG1hdHJpeCBvZiB0aGUgb3V0cHV0cyBvZiB0aGUgbmV0d29yayBmb3IgZWFjaCBpbnB1dCBpbiB0aGUgZ3JpZCByZXNwZWN0aXZlbHkuXG4gKi9cbmZ1bmN0aW9uIHVwZGF0ZURlY2lzaW9uQm91bmRhcnkobmV0d29yazogbm4uTm9kZVtdW10sIGZpcnN0VGltZTogYm9vbGVhbikge1xuICBpZiAoZmlyc3RUaW1lKSB7XG4gICAgYm91bmRhcnkgPSB7fTtcbiAgICBubi5mb3JFYWNoTm9kZShuZXR3b3JrLCB0cnVlLCBub2RlID0+IHtcbiAgICAgIGJvdW5kYXJ5W25vZGUuaWRdID0gbmV3IEFycmF5KERFTlNJVFkpO1xuICAgIH0pO1xuICAgIC8vIEdvIHRocm91Z2ggYWxsIHByZWRlZmluZWQgaW5wdXRzLlxuICAgIGZvciAobGV0IG5vZGVJZCBpbiBJTlBVVFMpIHtcbiAgICAgIGJvdW5kYXJ5W25vZGVJZF0gPSBuZXcgQXJyYXkoREVOU0lUWSk7XG4gICAgfVxuICB9XG4gIGxldCB4U2NhbGUgPSBkMy5zY2FsZS5saW5lYXIoKS5kb21haW4oWzAsIERFTlNJVFkgLSAxXSkucmFuZ2UoeERvbWFpbik7XG4gIGxldCB5U2NhbGUgPSBkMy5zY2FsZS5saW5lYXIoKS5kb21haW4oW0RFTlNJVFkgLSAxLCAwXSkucmFuZ2UoeERvbWFpbik7XG5cbiAgbGV0IGkgPSAwLCBqID0gMDtcbiAgZm9yIChpID0gMDsgaSA8IERFTlNJVFk7IGkrKykge1xuICAgIGlmIChmaXJzdFRpbWUpIHtcbiAgICAgIG5uLmZvckVhY2hOb2RlKG5ldHdvcmssIHRydWUsIG5vZGUgPT4ge1xuICAgICAgICBib3VuZGFyeVtub2RlLmlkXVtpXSA9IG5ldyBBcnJheShERU5TSVRZKTtcbiAgICAgIH0pO1xuICAgICAgLy8gR28gdGhyb3VnaCBhbGwgcHJlZGVmaW5lZCBpbnB1dHMuXG4gICAgICBmb3IgKGxldCBub2RlSWQgaW4gSU5QVVRTKSB7XG4gICAgICAgIGJvdW5kYXJ5W25vZGVJZF1baV0gPSBuZXcgQXJyYXkoREVOU0lUWSk7XG4gICAgICB9XG4gICAgfVxuICAgIGZvciAoaiA9IDA7IGogPCBERU5TSVRZOyBqKyspIHtcbiAgICAgIC8vIDEgZm9yIHBvaW50cyBpbnNpZGUgdGhlIGNpcmNsZSwgYW5kIDAgZm9yIHBvaW50cyBvdXRzaWRlIHRoZSBjaXJjbGUuXG4gICAgICBsZXQgeCA9IHhTY2FsZShpKTtcbiAgICAgIGxldCB5ID0geVNjYWxlKGopO1xuICAgICAgbGV0IGlucHV0ID0gY29uc3RydWN0SW5wdXQoeCwgeSk7XG4gICAgICBubi5mb3J3YXJkUHJvcChuZXR3b3JrLCBpbnB1dCk7XG4gICAgICBubi5mb3JFYWNoTm9kZShuZXR3b3JrLCB0cnVlLCBub2RlID0+IHtcbiAgICAgICAgYm91bmRhcnlbbm9kZS5pZF1baV1bal0gPSBub2RlLm91dHB1dDtcbiAgICAgIH0pO1xuICAgICAgaWYgKGZpcnN0VGltZSkge1xuICAgICAgICAvLyBHbyB0aHJvdWdoIGFsbCBwcmVkZWZpbmVkIGlucHV0cy5cbiAgICAgICAgZm9yIChsZXQgbm9kZUlkIGluIElOUFVUUykge1xuICAgICAgICAgIGJvdW5kYXJ5W25vZGVJZF1baV1bal0gPSBJTlBVVFNbbm9kZUlkXS5mKHgsIHkpO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgfVxuICB9XG59XG5cbmZ1bmN0aW9uIGdldExvc3MobmV0d29yazogbm4uTm9kZVtdW10sIGRhdGFQb2ludHM6IEV4YW1wbGUyRFtdKTogbnVtYmVyIHtcbiAgbGV0IGxvc3MgPSAwO1xuICBmb3IgKGxldCBpID0gMDsgaSA8IGRhdGFQb2ludHMubGVuZ3RoOyBpKyspIHtcbiAgICBsZXQgZGF0YVBvaW50ID0gZGF0YVBvaW50c1tpXTtcbiAgICBsZXQgaW5wdXQgPSBjb25zdHJ1Y3RJbnB1dChkYXRhUG9pbnQueCwgZGF0YVBvaW50LnkpO1xuICAgIGxldCBvdXRwdXQgPSBubi5mb3J3YXJkUHJvcChuZXR3b3JrLCBpbnB1dCk7XG4gICAgbG9zcyArPSBubi5FcnJvcnMuU1FVQVJFLmVycm9yKG91dHB1dCwgZGF0YVBvaW50LmxhYmVsKTtcbiAgfVxuICByZXR1cm4gbG9zcyAvIGRhdGFQb2ludHMubGVuZ3RoO1xufVxuXG5mdW5jdGlvbiB1cGRhdGVVSShmaXJzdFN0ZXAgPSBmYWxzZSkge1xuICAvLyBVcGRhdGUgdGhlIGxpbmtzIHZpc3VhbGx5LlxuICB1cGRhdGVXZWlnaHRzVUkobmV0d29yaywgZDMuc2VsZWN0KFwiZy5jb3JlXCIpKTtcbiAgLy8gVXBkYXRlIHRoZSBiaWFzIHZhbHVlcyB2aXN1YWxseS5cbiAgdXBkYXRlQmlhc2VzVUkobmV0d29yayk7XG4gIC8vIEdldCB0aGUgZGVjaXNpb24gYm91bmRhcnkgb2YgdGhlIG5ldHdvcmsuXG4gIHVwZGF0ZURlY2lzaW9uQm91bmRhcnkobmV0d29yaywgZmlyc3RTdGVwKTtcbiAgbGV0IHNlbGVjdGVkSWQgPSBzZWxlY3RlZE5vZGVJZCAhPSBudWxsID9cbiAgICAgIHNlbGVjdGVkTm9kZUlkIDogbm4uZ2V0T3V0cHV0Tm9kZShuZXR3b3JrKS5pZDtcbiAgaGVhdE1hcC51cGRhdGVCYWNrZ3JvdW5kKGJvdW5kYXJ5W3NlbGVjdGVkSWRdLCBzdGF0ZS5kaXNjcmV0aXplKTtcblxuICAvLyBVcGRhdGUgYWxsIGRlY2lzaW9uIGJvdW5kYXJpZXMuXG4gIGQzLnNlbGVjdChcIiNuZXR3b3JrXCIpLnNlbGVjdEFsbChcImRpdi5jYW52YXNcIilcbiAgICAgIC5lYWNoKGZ1bmN0aW9uKGRhdGE6IHtoZWF0bWFwOiBIZWF0TWFwLCBpZDogc3RyaW5nfSkge1xuICAgIGRhdGEuaGVhdG1hcC51cGRhdGVCYWNrZ3JvdW5kKHJlZHVjZU1hdHJpeChib3VuZGFyeVtkYXRhLmlkXSwgMTApLFxuICAgICAgICBzdGF0ZS5kaXNjcmV0aXplKTtcbiAgfSk7XG5cbiAgZnVuY3Rpb24gemVyb1BhZChuOiBudW1iZXIpOiBzdHJpbmcge1xuICAgIGxldCBwYWQgPSBcIjAwMDAwMFwiO1xuICAgIHJldHVybiAocGFkICsgbikuc2xpY2UoLXBhZC5sZW5ndGgpO1xuICB9XG5cbiAgZnVuY3Rpb24gYWRkQ29tbWFzKHM6IHN0cmluZyk6IHN0cmluZyB7XG4gICAgcmV0dXJuIHMucmVwbGFjZSgvXFxCKD89KFxcZHszfSkrKD8hXFxkKSkvZywgXCIsXCIpO1xuICB9XG5cbiAgZnVuY3Rpb24gaHVtYW5SZWFkYWJsZShuOiBudW1iZXIpOiBzdHJpbmcge1xuICAgIHJldHVybiBuLnRvRml4ZWQoMyk7XG4gIH1cblxuICAvLyBVcGRhdGUgbG9zcyBhbmQgaXRlcmF0aW9uIG51bWJlci5cbiAgZDMuc2VsZWN0KFwiI2xvc3MtdHJhaW5cIikudGV4dChodW1hblJlYWRhYmxlKGxvc3NUcmFpbikpO1xuICBkMy5zZWxlY3QoXCIjbG9zcy10ZXN0XCIpLnRleHQoaHVtYW5SZWFkYWJsZShsb3NzVGVzdCkpO1xuICBkMy5zZWxlY3QoXCIjaXRlci1udW1iZXJcIikudGV4dChhZGRDb21tYXMoemVyb1BhZChpdGVyKSkpO1xuICBsaW5lQ2hhcnQuYWRkRGF0YVBvaW50KFtsb3NzVHJhaW4sIGxvc3NUZXN0XSk7XG59XG5cbmZ1bmN0aW9uIGNvbnN0cnVjdElucHV0SWRzKCk6IHN0cmluZ1tdIHtcbiAgbGV0IHJlc3VsdDogc3RyaW5nW10gPSBbXTtcbiAgZm9yIChsZXQgaW5wdXROYW1lIGluIElOUFVUUykge1xuICAgIGlmIChzdGF0ZVtpbnB1dE5hbWVdKSB7XG4gICAgICByZXN1bHQucHVzaChpbnB1dE5hbWUpO1xuICAgIH1cbiAgfVxuICByZXR1cm4gcmVzdWx0O1xufVxuXG5mdW5jdGlvbiBjb25zdHJ1Y3RJbnB1dCh4OiBudW1iZXIsIHk6IG51bWJlcik6IG51bWJlcltdIHtcbiAgbGV0IGlucHV0OiBudW1iZXJbXSA9IFtdO1xuICBmb3IgKGxldCBpbnB1dE5hbWUgaW4gSU5QVVRTKSB7XG4gICAgaWYgKHN0YXRlW2lucHV0TmFtZV0pIHtcbiAgICAgIGlucHV0LnB1c2goSU5QVVRTW2lucHV0TmFtZV0uZih4LCB5KSk7XG4gICAgfVxuICB9XG4gIHJldHVybiBpbnB1dDtcbn1cblxuZnVuY3Rpb24gb25lU3RlcCgpOiB2b2lkIHtcbiAgaXRlcisrO1xuICB0cmFpbkRhdGEuZm9yRWFjaCgocG9pbnQsIGkpID0+IHtcbiAgICBsZXQgaW5wdXQgPSBjb25zdHJ1Y3RJbnB1dChwb2ludC54LCBwb2ludC55KTtcbiAgICBubi5mb3J3YXJkUHJvcChuZXR3b3JrLCBpbnB1dCk7XG4gICAgbm4uYmFja1Byb3AobmV0d29yaywgcG9pbnQubGFiZWwsIG5uLkVycm9ycy5TUVVBUkUpO1xuICAgIGlmICgoaSArIDEpICUgc3RhdGUuYmF0Y2hTaXplID09PSAwKSB7XG4gICAgICBubi51cGRhdGVXZWlnaHRzKG5ldHdvcmssIHN0YXRlLmxlYXJuaW5nUmF0ZSwgc3RhdGUucmVndWxhcml6YXRpb25SYXRlKTtcbiAgICB9XG4gIH0pO1xuICAvLyBDb21wdXRlIHRoZSBsb3NzLlxuICBsb3NzVHJhaW4gPSBnZXRMb3NzKG5ldHdvcmssIHRyYWluRGF0YSk7XG4gIGxvc3NUZXN0ID0gZ2V0TG9zcyhuZXR3b3JrLCB0ZXN0RGF0YSk7XG4gIHVwZGF0ZVVJKCk7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBnZXRPdXRwdXRXZWlnaHRzKG5ldHdvcms6IG5uLk5vZGVbXVtdKTogbnVtYmVyW10ge1xuICBsZXQgd2VpZ2h0czogbnVtYmVyW10gPSBbXTtcbiAgZm9yIChsZXQgbGF5ZXJJZHggPSAwOyBsYXllcklkeCA8IG5ldHdvcmsubGVuZ3RoIC0gMTsgbGF5ZXJJZHgrKykge1xuICAgIGxldCBjdXJyZW50TGF5ZXIgPSBuZXR3b3JrW2xheWVySWR4XTtcbiAgICBmb3IgKGxldCBpID0gMDsgaSA8IGN1cnJlbnRMYXllci5sZW5ndGg7IGkrKykge1xuICAgICAgbGV0IG5vZGUgPSBjdXJyZW50TGF5ZXJbaV07XG4gICAgICBmb3IgKGxldCBqID0gMDsgaiA8IG5vZGUub3V0cHV0cy5sZW5ndGg7IGorKykge1xuICAgICAgICBsZXQgb3V0cHV0ID0gbm9kZS5vdXRwdXRzW2pdO1xuICAgICAgICB3ZWlnaHRzLnB1c2gob3V0cHV0LndlaWdodCk7XG4gICAgICB9XG4gICAgfVxuICB9XG4gIHJldHVybiB3ZWlnaHRzO1xufVxuXG5mdW5jdGlvbiBzZXRPdXRwdXRXZWlnaHRzKG5ldHdvcms6IG5uLk5vZGVbXVtdLCB3ZWlnaHRzOiBudW1iZXJbXSl7XG4gIGxldCBpZHg6IG51bWJlciA9IDA7XG4gIGZvciAobGV0IGxheWVySWR4ID0gMDsgbGF5ZXJJZHggPCBuZXR3b3JrLmxlbmd0aCAtIDE7IGxheWVySWR4KyspIHtcbiAgICBsZXQgY3VycmVudExheWVyID0gbmV0d29ya1tsYXllcklkeF07XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjdXJyZW50TGF5ZXIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGxldCBub2RlID0gY3VycmVudExheWVyW2ldO1xuICAgICAgZm9yIChsZXQgaiA9IDA7IGogPCBub2RlLm91dHB1dHMubGVuZ3RoOyBqKyspIHtcbiAgICAgICAgbm9kZS5vdXRwdXRzW2pdLndlaWdodCA9IHdlaWdodHNbaWR4KytdO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG5mdW5jdGlvbiByZXNldCgpIHtcbiAgbGluZUNoYXJ0LnJlc2V0KCk7XG4gIHN0YXRlLnNlcmlhbGl6ZSgpO1xuICBwbGF5ZXIucGF1c2UoKTtcblxuICBsZXQgc3VmZml4ID0gc3RhdGUubnVtSGlkZGVuTGF5ZXJzICE9PSAxID8gXCJzXCIgOiBcIlwiO1xuICBkMy5zZWxlY3QoXCIjbGF5ZXJzLWxhYmVsXCIpLnRleHQoXCJIaWRkZW4gbGF5ZXJcIiArIHN1ZmZpeCk7XG4gIGQzLnNlbGVjdChcIiNudW0tbGF5ZXJzXCIpLnRleHQoc3RhdGUubnVtSGlkZGVuTGF5ZXJzKTtcblxuICAvLyBNYWtlIGEgc2ltcGxlIG5ldHdvcmsuXG4gIGl0ZXIgPSAwO1xuICBsZXQgbnVtSW5wdXRzID0gY29uc3RydWN0SW5wdXQoMCAsIDApLmxlbmd0aDtcbiAgbGV0IHNoYXBlID0gW251bUlucHV0c10uY29uY2F0KHN0YXRlLm5ldHdvcmtTaGFwZSkuY29uY2F0KFsxXSk7XG4gIGxldCBvdXRwdXRBY3RpdmF0aW9uID0gKHN0YXRlLnByb2JsZW0gPT0gUHJvYmxlbS5SRUdSRVNTSU9OKSA/XG4gICAgICBubi5BY3RpdmF0aW9ucy5MSU5FQVIgOiBubi5BY3RpdmF0aW9ucy5UQU5IO1xuICBuZXR3b3JrID0gbm4uYnVpbGROZXR3b3JrKHNoYXBlLCBzdGF0ZS5hY3RpdmF0aW9uLCBvdXRwdXRBY3RpdmF0aW9uLFxuICAgICAgc3RhdGUucmVndWxhcml6YXRpb24sIGNvbnN0cnVjdElucHV0SWRzKCkpO1xuICBsb3NzVHJhaW4gPSBnZXRMb3NzKG5ldHdvcmssIHRyYWluRGF0YSk7XG4gIGxvc3NUZXN0ID0gZ2V0TG9zcyhuZXR3b3JrLCB0ZXN0RGF0YSk7XG4gIGRyYXdOZXR3b3JrKG5ldHdvcmspO1xuICB1cGRhdGVVSSh0cnVlKTtcbn07XG5cbmZ1bmN0aW9uIHVwZGF0ZUFjdGl2YXRpb24oKSB7XG4gIHN0YXRlLnNlcmlhbGl6ZSgpO1xuICBsZXQgbnVtSW5wdXRzID0gY29uc3RydWN0SW5wdXQoMCAsIDApLmxlbmd0aDtcbiAgbGV0IHNoYXBlID0gW251bUlucHV0c10uY29uY2F0KHN0YXRlLm5ldHdvcmtTaGFwZSkuY29uY2F0KFsxXSk7XG4gIGxldCBvdXRwdXRBY3RpdmF0aW9uID0gKHN0YXRlLnByb2JsZW0gPT0gUHJvYmxlbS5SRUdSRVNTSU9OKSA/XG4gICAgICBubi5BY3RpdmF0aW9ucy5MSU5FQVIgOiBubi5BY3RpdmF0aW9ucy5UQU5IO1xuICBsZXQgd2VpZ2h0cyA9IGdldE91dHB1dFdlaWdodHMobmV0d29yayk7XG4gIG5ldHdvcmsgPSBubi5idWlsZE5ldHdvcmsoc2hhcGUsIHN0YXRlLmFjdGl2YXRpb24sIG91dHB1dEFjdGl2YXRpb24sXG4gICAgICBzdGF0ZS5yZWd1bGFyaXphdGlvbiwgY29uc3RydWN0SW5wdXRJZHMoKSk7XG4gIHNldE91dHB1dFdlaWdodHMobmV0d29yaywgd2VpZ2h0cyk7XG59O1xuXG5cbmZ1bmN0aW9uIGluaXRUdXRvcmlhbCgpIHtcbiAgaWYgKHN0YXRlLnR1dG9yaWFsID09IG51bGwpIHtcbiAgICByZXR1cm47XG4gIH1cbiAgLy8gUmVtb3ZlIGFsbCBvdGhlciB0ZXh0LlxuICBkMy5zZWxlY3RBbGwoXCJhcnRpY2xlIGRpdi5sLS1ib2R5XCIpLnJlbW92ZSgpO1xuICBsZXQgdHV0b3JpYWwgPSBkMy5zZWxlY3QoXCJhcnRpY2xlXCIpLmFwcGVuZChcImRpdlwiKVxuICAgIC5hdHRyKFwiY2xhc3NcIiwgXCJsLS1ib2R5XCIpO1xuICAvLyBJbnNlcnQgdHV0b3JpYWwgdGV4dC5cbiAgZDMuaHRtbChgdHV0b3JpYWxzLyR7c3RhdGUudHV0b3JpYWx9Lmh0bWxgLCAoZXJyLCBodG1sRnJhZ21lbnQpID0+IHtcbiAgICBpZiAoZXJyKSB7XG4gICAgICB0aHJvdyBlcnI7XG4gICAgfVxuICAgICg8YW55PnR1dG9yaWFsLm5vZGUoKSkuYXBwZW5kQ2hpbGQoaHRtbEZyYWdtZW50KTtcbiAgICAvLyBJZiB0aGUgdHV0b3JpYWwgaGFzIGEgPHRpdGxlPiB0YWcsIHNldCB0aGUgcGFnZSB0aXRsZSB0byB0aGF0LlxuICAgIGxldCB0aXRsZSA9IHR1dG9yaWFsLnNlbGVjdChcInRpdGxlXCIpO1xuICAgIGlmICh0aXRsZS5zaXplKCkpIHtcbiAgICAgIGQzLnNlbGVjdChcImhlYWRlciBoMVwiKS5zdHlsZSh7XG4gICAgICAgIFwibWFyZ2luLXRvcFwiOiBcIjIwcHhcIixcbiAgICAgICAgXCJtYXJnaW4tYm90dG9tXCI6IFwiMjBweFwiLFxuICAgICAgfSlcbiAgICAgIC50ZXh0KHRpdGxlLnRleHQoKSk7XG4gICAgICBkb2N1bWVudC50aXRsZSA9IHRpdGxlLnRleHQoKTtcbiAgICB9XG4gIH0pO1xufVxuXG5mdW5jdGlvbiBkcmF3RGF0YXNldFRodW1ibmFpbHMoKSB7XG4gIGZ1bmN0aW9uIHJlbmRlclRodW1ibmFpbChjYW52YXMsIGRhdGFHZW5lcmF0b3IpIHtcbiAgICBsZXQgdyA9IDEwMDtcbiAgICBsZXQgaCA9IDEwMDtcbiAgICBjYW52YXMuc2V0QXR0cmlidXRlKFwid2lkdGhcIiwgdyk7XG4gICAgY2FudmFzLnNldEF0dHJpYnV0ZShcImhlaWdodFwiLCBoKTtcbiAgICBsZXQgY29udGV4dCA9IGNhbnZhcy5nZXRDb250ZXh0KFwiMmRcIik7XG4gICAgbGV0IGRhdGEgPSBkYXRhR2VuZXJhdG9yKDIwMCwgMCk7XG4gICAgZGF0YS5mb3JFYWNoKGZ1bmN0aW9uKGQpIHtcbiAgICAgIGNvbnRleHQuZmlsbFN0eWxlID0gY29sb3JTY2FsZShkLmxhYmVsKTtcbiAgICAgIGNvbnRleHQuZmlsbFJlY3QodyAqIChkLnggKyA2KSAvIDEyLCBoICogKGQueSArIDYpIC8gMTIsIDQsIDQpO1xuICAgIH0pO1xuICAgIGQzLnNlbGVjdChjYW52YXMucGFyZW50Tm9kZSkuc3R5bGUoXCJkaXNwbGF5XCIsIG51bGwpO1xuICB9XG4gIGQzLnNlbGVjdEFsbChcIi5kYXRhc2V0XCIpLnN0eWxlKFwiZGlzcGxheVwiLCBcIm5vbmVcIik7XG5cbiAgaWYgKHN0YXRlLnByb2JsZW0gPT0gUHJvYmxlbS5DTEFTU0lGSUNBVElPTikge1xuICAgIGZvciAobGV0IGRhdGFzZXQgaW4gZGF0YXNldHMpIHtcbiAgICAgIGxldCBjYW52YXM6IGFueSA9XG4gICAgICAgICAgZG9jdW1lbnQucXVlcnlTZWxlY3RvcihgY2FudmFzW2RhdGEtZGF0YXNldD0ke2RhdGFzZXR9XWApO1xuICAgICAgbGV0IGRhdGFHZW5lcmF0b3IgPSBkYXRhc2V0c1tkYXRhc2V0XTtcbiAgICAgIHJlbmRlclRodW1ibmFpbChjYW52YXMsIGRhdGFHZW5lcmF0b3IpO1xuICAgIH1cbiAgfVxuICBpZiAoc3RhdGUucHJvYmxlbSA9PSBQcm9ibGVtLlJFR1JFU1NJT04pIHtcbiAgICBmb3IgKGxldCByZWdEYXRhc2V0IGluIHJlZ0RhdGFzZXRzKSB7XG4gICAgICBsZXQgY2FudmFzOiBhbnkgPVxuICAgICAgICAgIGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoYGNhbnZhc1tkYXRhLXJlZ0RhdGFzZXQ9JHtyZWdEYXRhc2V0fV1gKTtcbiAgICAgIGxldCBkYXRhR2VuZXJhdG9yID0gcmVnRGF0YXNldHNbcmVnRGF0YXNldF07XG4gICAgICByZW5kZXJUaHVtYm5haWwoY2FudmFzLCBkYXRhR2VuZXJhdG9yKTtcbiAgICB9XG4gIH1cbn1cblxuZnVuY3Rpb24gaGlkZUNvbnRyb2xzKCkge1xuICAvLyBTZXQgZGlzcGxheTpub25lIHRvIGFsbCB0aGUgVUkgZWxlbWVudHMgdGhhdCBhcmUgaGlkZGVuLlxuICBsZXQgaGlkZGVuUHJvcHMgPSBzdGF0ZS5nZXRIaWRkZW5Qcm9wcygpO1xuICBoaWRkZW5Qcm9wcy5mb3JFYWNoKHByb3AgPT4ge1xuICAgIGxldCBjb250cm9scyA9IGQzLnNlbGVjdEFsbChgLnVpLSR7cHJvcH1gKTtcbiAgICBpZiAoY29udHJvbHMuc2l6ZSgpID09IDApIHtcbiAgICAgIGNvbnNvbGUud2FybihgMCBodG1sIGVsZW1lbnRzIGZvdW5kIHdpdGggY2xhc3MgLnVpLSR7cHJvcH1gKTtcbiAgICB9XG4gICAgY29udHJvbHMuc3R5bGUoXCJkaXNwbGF5XCIsIFwibm9uZVwiKTtcbiAgfSk7XG5cbiAgLy8gQWxzbyBhZGQgY2hlY2tib3ggZm9yIGVhY2ggaGlkYWJsZSBjb250cm9sIGluIHRoZSBcInVzZSBpdCBpbiBjbGFzc3JvbVwiXG4gIC8vIHNlY3Rpb24uXG4gIGxldCBoaWRlQ29udHJvbHMgPSBkMy5zZWxlY3QoXCIuaGlkZS1jb250cm9sc1wiKTtcbiAgSElEQUJMRV9DT05UUk9MUy5mb3JFYWNoKChbdGV4dCwgaWRdKSA9PiB7XG4gICAgbGV0IGxhYmVsID0gaGlkZUNvbnRyb2xzLmFwcGVuZChcImxhYmVsXCIpXG4gICAgICAuYXR0cihcImNsYXNzXCIsIFwibWRsLWNoZWNrYm94IG1kbC1qcy1jaGVja2JveCBtZGwtanMtcmlwcGxlLWVmZmVjdFwiKTtcbiAgICBsZXQgaW5wdXQgPSBsYWJlbC5hcHBlbmQoXCJpbnB1dFwiKVxuICAgICAgLmF0dHIoe1xuICAgICAgICB0eXBlOiBcImNoZWNrYm94XCIsXG4gICAgICAgIGNsYXNzOiBcIm1kbC1jaGVja2JveF9faW5wdXRcIixcbiAgICAgIH0pO1xuICAgIGlmIChoaWRkZW5Qcm9wcy5pbmRleE9mKGlkKSA9PSAtMSkge1xuICAgICAgaW5wdXQuYXR0cihcImNoZWNrZWRcIiwgXCJ0cnVlXCIpO1xuICAgIH1cbiAgICBpbnB1dC5vbihcImNoYW5nZVwiLCBmdW5jdGlvbigpIHtcbiAgICAgIHN0YXRlLnNldEhpZGVQcm9wZXJ0eShpZCwgIXRoaXMuY2hlY2tlZCk7XG4gICAgICBzdGF0ZS5zZXJpYWxpemUoKTtcbiAgICAgIGQzLnNlbGVjdChcIi5oaWRlLWNvbnRyb2xzLWxpbmtcIilcbiAgICAgICAgLmF0dHIoXCJocmVmXCIsIHdpbmRvdy5sb2NhdGlvbi5ocmVmKTtcbiAgICB9KTtcbiAgICBsYWJlbC5hcHBlbmQoXCJzcGFuXCIpXG4gICAgICAuYXR0cihcImNsYXNzXCIsIFwibWRsLWNoZWNrYm94X19sYWJlbCBsYWJlbFwiKVxuICAgICAgLnRleHQodGV4dCk7XG4gIH0pO1xuICBkMy5zZWxlY3QoXCIuaGlkZS1jb250cm9scy1saW5rXCIpXG4gICAgLmF0dHIoXCJocmVmXCIsIHdpbmRvdy5sb2NhdGlvbi5ocmVmKTtcbn1cblxuZnVuY3Rpb24gZ2VuZXJhdGVEYXRhKGZpcnN0VGltZSA9IGZhbHNlKSB7XG4gIGlmICghZmlyc3RUaW1lKSB7XG4gICAgLy8gQ2hhbmdlIHRoZSBzZWVkLlxuICAgIHN0YXRlLnNlZWQgPSBNYXRoLnJhbmRvbSgpLnRvRml4ZWQoNSk7XG4gICAgc3RhdGUuc2VyaWFsaXplKCk7XG4gIH1cbiAgTWF0aC5zZWVkcmFuZG9tKHN0YXRlLnNlZWQpO1xuICBsZXQgbnVtU2FtcGxlcyA9IChzdGF0ZS5wcm9ibGVtID09IFByb2JsZW0uUkVHUkVTU0lPTikgP1xuICAgICAgTlVNX1NBTVBMRVNfUkVHUkVTUyA6IE5VTV9TQU1QTEVTX0NMQVNTSUZZO1xuICBsZXQgZ2VuZXJhdG9yID0gc3RhdGUucHJvYmxlbSA9PSBQcm9ibGVtLkNMQVNTSUZJQ0FUSU9OID9cbiAgICAgIHN0YXRlLmRhdGFzZXQgOiBzdGF0ZS5yZWdEYXRhc2V0O1xuICBsZXQgZGF0YSA9IGdlbmVyYXRvcihudW1TYW1wbGVzLCBzdGF0ZS5ub2lzZSAvIDEwMCk7XG4gIC8vIFNodWZmbGUgdGhlIGRhdGEgaW4tcGxhY2UuXG4gIHNodWZmbGUoZGF0YSk7XG4gIC8vIFNwbGl0IGludG8gdHJhaW4gYW5kIHRlc3QgZGF0YS5cbiAgbGV0IHNwbGl0SW5kZXggPSBNYXRoLmZsb29yKGRhdGEubGVuZ3RoICogc3RhdGUucGVyY1RyYWluRGF0YSAvIDEwMCk7XG4gIHRyYWluRGF0YSA9IGRhdGEuc2xpY2UoMCwgc3BsaXRJbmRleCk7XG4gIHRlc3REYXRhID0gZGF0YS5zbGljZShzcGxpdEluZGV4KTtcbiAgaGVhdE1hcC51cGRhdGVQb2ludHModHJhaW5EYXRhKTtcbiAgaGVhdE1hcC51cGRhdGVUZXN0UG9pbnRzKHN0YXRlLnNob3dUZXN0RGF0YSA/IHRlc3REYXRhIDogW10pO1xufVxuXG5kcmF3RGF0YXNldFRodW1ibmFpbHMoKTtcbmluaXRUdXRvcmlhbCgpO1xubWFrZUdVSSgpO1xuZ2VuZXJhdGVEYXRhKHRydWUpO1xucmVzZXQoKTtcbmhpZGVDb250cm9scygpO1xuIiwiLyogQ29weXJpZ2h0IDIwMTYgR29vZ2xlIEluYy4gQWxsIFJpZ2h0cyBSZXNlcnZlZC5cblxuTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlIFwiTGljZW5zZVwiKTtcbnlvdSBtYXkgbm90IHVzZSB0aGlzIGZpbGUgZXhjZXB0IGluIGNvbXBsaWFuY2Ugd2l0aCB0aGUgTGljZW5zZS5cbllvdSBtYXkgb2J0YWluIGEgY29weSBvZiB0aGUgTGljZW5zZSBhdFxuXG4gICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wXG5cblVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyBvciBhZ3JlZWQgdG8gaW4gd3JpdGluZywgc29mdHdhcmVcbmRpc3RyaWJ1dGVkIHVuZGVyIHRoZSBMaWNlbnNlIGlzIGRpc3RyaWJ1dGVkIG9uIGFuIFwiQVMgSVNcIiBCQVNJUyxcbldJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLlxuU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZFxubGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuXG49PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0qL1xuXG5pbXBvcnQgKiBhcyBubiBmcm9tIFwiLi9ublwiO1xuaW1wb3J0ICogYXMgZGF0YXNldCBmcm9tIFwiLi9kYXRhc2V0XCI7XG5cbi8qKiBTdWZmaXggYWRkZWQgdG8gdGhlIHN0YXRlIHdoZW4gc3RvcmluZyBpZiBhIGNvbnRyb2wgaXMgaGlkZGVuIG9yIG5vdC4gKi9cbmNvbnN0IEhJREVfU1RBVEVfU1VGRklYID0gXCJfaGlkZVwiO1xuXG4vKiogQSBtYXAgYmV0d2VlbiBuYW1lcyBhbmQgYWN0aXZhdGlvbiBmdW5jdGlvbnMuICovXG5leHBvcnQgbGV0IGFjdGl2YXRpb25zOiB7W2tleTogc3RyaW5nXTogbm4uQWN0aXZhdGlvbkZ1bmN0aW9ufSA9IHtcbiAgXCJhcmN0YW5cIjogbm4uQWN0aXZhdGlvbnMuQVJDVEFOLFxuICBcImJlbnRcIjogbm4uQWN0aXZhdGlvbnMuQkVOVCxcbiAgXCJlbHVcIjogbm4uQWN0aXZhdGlvbnMuRUxVLFxuICBcImdhdXNzaWFuXCI6IG5uLkFjdGl2YXRpb25zLkdBVVNTSUFOLFxuICBcImxpbmVhclwiOiBubi5BY3RpdmF0aW9ucy5MSU5FQVIsXG4gIFwicmVsdVwiOiBubi5BY3RpdmF0aW9ucy5SRUxVLFxuICBcInNpZ21vaWRcIjogbm4uQWN0aXZhdGlvbnMuU0lHTU9JRCxcbiAgXCJzaW5cIjogbm4uQWN0aXZhdGlvbnMuU0lOVVNPSUQsXG4gIFwic29mdHBsdXNcIjogbm4uQWN0aXZhdGlvbnMuU09GVFBMVVMsXG4gIFwic29mdHNpZ25cIjogbm4uQWN0aXZhdGlvbnMuU09GVFNJR04sXG4gIFwidGFuaFwiOiBubi5BY3RpdmF0aW9ucy5UQU5IXG59O1xuXG4vKiogQSBtYXAgYmV0d2VlbiBuYW1lcyBhbmQgcmVndWxhcml6YXRpb24gZnVuY3Rpb25zLiAqL1xuZXhwb3J0IGxldCByZWd1bGFyaXphdGlvbnM6IHtba2V5OiBzdHJpbmddOiBubi5SZWd1bGFyaXphdGlvbkZ1bmN0aW9ufSA9IHtcbiAgXCJub25lXCI6IG51bGwsXG4gIFwiTDFcIjogbm4uUmVndWxhcml6YXRpb25GdW5jdGlvbi5MMSxcbiAgXCJMMlwiOiBubi5SZWd1bGFyaXphdGlvbkZ1bmN0aW9uLkwyXG59O1xuXG4vKiogQSBtYXAgYmV0d2VlbiBkYXRhc2V0IG5hbWVzIGFuZCBmdW5jdGlvbnMgdGhhdCBnZW5lcmF0ZSBjbGFzc2lmaWNhdGlvbiBkYXRhLiAqL1xuZXhwb3J0IGxldCBkYXRhc2V0czoge1trZXk6IHN0cmluZ106IGRhdGFzZXQuRGF0YUdlbmVyYXRvcn0gPSB7XG4gIFwiY2lyY2xlXCI6IGRhdGFzZXQuY2xhc3NpZnlDaXJjbGVEYXRhLFxuICBcInhvclwiOiBkYXRhc2V0LmNsYXNzaWZ5WE9SRGF0YSxcbiAgXCJnYXVzc1wiOiBkYXRhc2V0LmNsYXNzaWZ5VHdvR2F1c3NEYXRhLFxuICBcInNwaXJhbFwiOiBkYXRhc2V0LmNsYXNzaWZ5U3BpcmFsRGF0YSxcbn07XG5cbi8qKiBBIG1hcCBiZXR3ZWVuIGRhdGFzZXQgbmFtZXMgYW5kIGZ1bmN0aW9ucyB0aGF0IGdlbmVyYXRlIHJlZ3Jlc3Npb24gZGF0YS4gKi9cbmV4cG9ydCBsZXQgcmVnRGF0YXNldHM6IHtba2V5OiBzdHJpbmddOiBkYXRhc2V0LkRhdGFHZW5lcmF0b3J9ID0ge1xuICBcInJlZy1wbGFuZVwiOiBkYXRhc2V0LnJlZ3Jlc3NQbGFuZSxcbiAgXCJyZWctZ2F1c3NcIjogZGF0YXNldC5yZWdyZXNzR2F1c3NpYW5cbn07XG5cbmV4cG9ydCBmdW5jdGlvbiBnZXRLZXlGcm9tVmFsdWUob2JqOiBhbnksIHZhbHVlOiBhbnkpOiBzdHJpbmcge1xuICBmb3IgKGxldCBrZXkgaW4gb2JqKSB7XG4gICAgaWYgKG9ialtrZXldID09PSB2YWx1ZSkge1xuICAgICAgcmV0dXJuIGtleTtcbiAgICB9XG4gIH1cbiAgcmV0dXJuIHVuZGVmaW5lZDtcbn1cblxuZnVuY3Rpb24gZW5kc1dpdGgoczogc3RyaW5nLCBzdWZmaXg6IHN0cmluZyk6IGJvb2xlYW4ge1xuICByZXR1cm4gcy5zdWJzdHIoLXN1ZmZpeC5sZW5ndGgpID09PSBzdWZmaXg7XG59XG5cbmZ1bmN0aW9uIGdldEhpZGVQcm9wcyhvYmo6IGFueSk6IHN0cmluZ1tdIHtcbiAgbGV0IHJlc3VsdDogc3RyaW5nW10gPSBbXTtcbiAgZm9yIChsZXQgcHJvcCBpbiBvYmopIHtcbiAgICBpZiAoZW5kc1dpdGgocHJvcCwgSElERV9TVEFURV9TVUZGSVgpKSB7XG4gICAgICByZXN1bHQucHVzaChwcm9wKTtcbiAgICB9XG4gIH1cbiAgcmV0dXJuIHJlc3VsdDtcbn1cblxuLyoqXG4gKiBUaGUgZGF0YSB0eXBlIG9mIGEgc3RhdGUgdmFyaWFibGUuIFVzZWQgZm9yIGRldGVybWluaW5nIHRoZVxuICogKGRlKXNlcmlhbGl6YXRpb24gbWV0aG9kLlxuICovXG5leHBvcnQgZW51bSBUeXBlIHtcbiAgU1RSSU5HLFxuICBOVU1CRVIsXG4gIEFSUkFZX05VTUJFUixcbiAgQVJSQVlfU1RSSU5HLFxuICBCT09MRUFOLFxuICBPQkpFQ1Rcbn1cblxuZXhwb3J0IGVudW0gUHJvYmxlbSB7XG4gIENMQVNTSUZJQ0FUSU9OLFxuICBSRUdSRVNTSU9OXG59XG5cbmV4cG9ydCBsZXQgcHJvYmxlbXMgPSB7XG4gIFwiY2xhc3NpZmljYXRpb25cIjogUHJvYmxlbS5DTEFTU0lGSUNBVElPTixcbiAgXCJyZWdyZXNzaW9uXCI6IFByb2JsZW0uUkVHUkVTU0lPTlxufTtcblxuZXhwb3J0IGludGVyZmFjZSBQcm9wZXJ0eSB7XG4gIG5hbWU6IHN0cmluZztcbiAgdHlwZTogVHlwZTtcbiAga2V5TWFwPzoge1trZXk6IHN0cmluZ106IGFueX07XG59O1xuXG4vLyBBZGQgdGhlIEdVSSBzdGF0ZS5cbmV4cG9ydCBjbGFzcyBTdGF0ZSB7XG5cbiAgcHJpdmF0ZSBzdGF0aWMgUFJPUFM6IFByb3BlcnR5W10gPSBbXG4gICAge25hbWU6IFwiYWN0aXZhdGlvblwiLCB0eXBlOiBUeXBlLk9CSkVDVCwga2V5TWFwOiBhY3RpdmF0aW9uc30sXG4gICAge25hbWU6IFwicmVndWxhcml6YXRpb25cIiwgdHlwZTogVHlwZS5PQkpFQ1QsIGtleU1hcDogcmVndWxhcml6YXRpb25zfSxcbiAgICB7bmFtZTogXCJiYXRjaFNpemVcIiwgdHlwZTogVHlwZS5OVU1CRVJ9LFxuICAgIHtuYW1lOiBcImRhdGFzZXRcIiwgdHlwZTogVHlwZS5PQkpFQ1QsIGtleU1hcDogZGF0YXNldHN9LFxuICAgIHtuYW1lOiBcInJlZ0RhdGFzZXRcIiwgdHlwZTogVHlwZS5PQkpFQ1QsIGtleU1hcDogcmVnRGF0YXNldHN9LFxuICAgIHtuYW1lOiBcImxlYXJuaW5nUmF0ZVwiLCB0eXBlOiBUeXBlLk5VTUJFUn0sXG4gICAge25hbWU6IFwicmVndWxhcml6YXRpb25SYXRlXCIsIHR5cGU6IFR5cGUuTlVNQkVSfSxcbiAgICB7bmFtZTogXCJub2lzZVwiLCB0eXBlOiBUeXBlLk5VTUJFUn0sXG4gICAge25hbWU6IFwibmV0d29ya1NoYXBlXCIsIHR5cGU6IFR5cGUuQVJSQVlfTlVNQkVSfSxcbiAgICB7bmFtZTogXCJzZWVkXCIsIHR5cGU6IFR5cGUuU1RSSU5HfSxcbiAgICB7bmFtZTogXCJzaG93VGVzdERhdGFcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJkaXNjcmV0aXplXCIsIHR5cGU6IFR5cGUuQk9PTEVBTn0sXG4gICAge25hbWU6IFwicGVyY1RyYWluRGF0YVwiLCB0eXBlOiBUeXBlLk5VTUJFUn0sXG4gICAge25hbWU6IFwieFwiLCB0eXBlOiBUeXBlLkJPT0xFQU59LFxuICAgIHtuYW1lOiBcInlcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJ4VGltZXNZXCIsIHR5cGU6IFR5cGUuQk9PTEVBTn0sXG4gICAge25hbWU6IFwieFNxdWFyZWRcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJ5U3F1YXJlZFwiLCB0eXBlOiBUeXBlLkJPT0xFQU59LFxuICAgIHtuYW1lOiBcImNvc1hcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJzaW5YXCIsIHR5cGU6IFR5cGUuQk9PTEVBTn0sXG4gICAge25hbWU6IFwiY29zWVwiLCB0eXBlOiBUeXBlLkJPT0xFQU59LFxuICAgIHtuYW1lOiBcInNpbllcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJjb2xsZWN0U3RhdHNcIiwgdHlwZTogVHlwZS5CT09MRUFOfSxcbiAgICB7bmFtZTogXCJ0dXRvcmlhbFwiLCB0eXBlOiBUeXBlLlNUUklOR30sXG4gICAge25hbWU6IFwicHJvYmxlbVwiLCB0eXBlOiBUeXBlLk9CSkVDVCwga2V5TWFwOiBwcm9ibGVtc31cbiAgXTtcblxuICBba2V5OiBzdHJpbmddOiBhbnk7XG4gIGxlYXJuaW5nUmF0ZSA9IDAuMDM7XG4gIHJlZ3VsYXJpemF0aW9uUmF0ZSA9IDA7XG4gIHNob3dUZXN0RGF0YSA9IGZhbHNlO1xuICBub2lzZSA9IDA7XG4gIGJhdGNoU2l6ZSA9IDEwO1xuICBkaXNjcmV0aXplID0gZmFsc2U7XG4gIHR1dG9yaWFsOiBzdHJpbmcgPSBudWxsO1xuICBwZXJjVHJhaW5EYXRhID0gNTA7XG4gIGFjdGl2YXRpb24gPSBubi5BY3RpdmF0aW9ucy5UQU5IO1xuICByZWd1bGFyaXphdGlvbjogbm4uUmVndWxhcml6YXRpb25GdW5jdGlvbiA9IG51bGw7XG4gIHByb2JsZW0gPSBQcm9ibGVtLkNMQVNTSUZJQ0FUSU9OO1xuICBjb2xsZWN0U3RhdHMgPSBmYWxzZTtcbiAgbnVtSGlkZGVuTGF5ZXJzID0gMTtcbiAgaGlkZGVuTGF5ZXJDb250cm9sczogYW55W10gPSBbXTtcbiAgbmV0d29ya1NoYXBlOiBudW1iZXJbXSA9IFs0LCAyXTtcbiAgeCA9IHRydWU7XG4gIHkgPSB0cnVlO1xuICB4VGltZXNZID0gZmFsc2U7XG4gIHhTcXVhcmVkID0gZmFsc2U7XG4gIHlTcXVhcmVkID0gZmFsc2U7XG4gIGNvc1ggPSBmYWxzZTtcbiAgc2luWCA9IGZhbHNlO1xuICBjb3NZID0gZmFsc2U7XG4gIHNpblkgPSBmYWxzZTtcbiAgZGF0YXNldDogZGF0YXNldC5EYXRhR2VuZXJhdG9yID0gZGF0YXNldC5jbGFzc2lmeUNpcmNsZURhdGE7XG4gIHJlZ0RhdGFzZXQ6IGRhdGFzZXQuRGF0YUdlbmVyYXRvciA9IGRhdGFzZXQucmVncmVzc1BsYW5lO1xuICBzZWVkOiBzdHJpbmc7XG5cbiAgLyoqXG4gICAqIERlc2VyaWFsaXplcyB0aGUgc3RhdGUgZnJvbSB0aGUgdXJsIGhhc2guXG4gICAqL1xuICBzdGF0aWMgZGVzZXJpYWxpemVTdGF0ZSgpOiBTdGF0ZSB7XG4gICAgbGV0IG1hcDoge1trZXk6IHN0cmluZ106IHN0cmluZ30gPSB7fTtcbiAgICBmb3IgKGxldCBrZXl2YWx1ZSBvZiB3aW5kb3cubG9jYXRpb24uaGFzaC5zbGljZSgxKS5zcGxpdChcIiZcIikpIHtcbiAgICAgIGxldCBbbmFtZSwgdmFsdWVdID0ga2V5dmFsdWUuc3BsaXQoXCI9XCIpO1xuICAgICAgbWFwW25hbWVdID0gdmFsdWU7XG4gICAgfVxuICAgIGxldCBzdGF0ZSA9IG5ldyBTdGF0ZSgpO1xuXG4gICAgZnVuY3Rpb24gaGFzS2V5KG5hbWU6IHN0cmluZyk6IGJvb2xlYW4ge1xuICAgICAgcmV0dXJuIG5hbWUgaW4gbWFwICYmIG1hcFtuYW1lXSAhPSBudWxsICYmIG1hcFtuYW1lXS50cmltKCkgIT09IFwiXCI7XG4gICAgfVxuXG4gICAgZnVuY3Rpb24gcGFyc2VBcnJheSh2YWx1ZTogc3RyaW5nKTogc3RyaW5nW10ge1xuICAgICAgcmV0dXJuIHZhbHVlLnRyaW0oKSA9PT0gXCJcIiA/IFtdIDogdmFsdWUuc3BsaXQoXCIsXCIpO1xuICAgIH1cblxuICAgIC8vIERlc2VyaWFsaXplIHJlZ3VsYXIgcHJvcGVydGllcy5cbiAgICBTdGF0ZS5QUk9QUy5mb3JFYWNoKCh7bmFtZSwgdHlwZSwga2V5TWFwfSkgPT4ge1xuICAgICAgc3dpdGNoICh0eXBlKSB7XG4gICAgICAgIGNhc2UgVHlwZS5PQkpFQ1Q6XG4gICAgICAgICAgaWYgKGtleU1hcCA9PSBudWxsKSB7XG4gICAgICAgICAgICB0aHJvdyBFcnJvcihcIkEga2V5LXZhbHVlIG1hcCBtdXN0IGJlIHByb3ZpZGVkIGZvciBzdGF0ZSBcIiArXG4gICAgICAgICAgICAgICAgXCJ2YXJpYWJsZXMgb2YgdHlwZSBPYmplY3RcIik7XG4gICAgICAgICAgfVxuICAgICAgICAgIGlmIChoYXNLZXkobmFtZSkgJiYgbWFwW25hbWVdIGluIGtleU1hcCkge1xuICAgICAgICAgICAgc3RhdGVbbmFtZV0gPSBrZXlNYXBbbWFwW25hbWVdXTtcbiAgICAgICAgICB9XG4gICAgICAgICAgYnJlYWs7XG4gICAgICAgIGNhc2UgVHlwZS5OVU1CRVI6XG4gICAgICAgICAgaWYgKGhhc0tleShuYW1lKSkge1xuICAgICAgICAgICAgLy8gVGhlICsgb3BlcmF0b3IgaXMgZm9yIGNvbnZlcnRpbmcgYSBzdHJpbmcgdG8gYSBudW1iZXIuXG4gICAgICAgICAgICBzdGF0ZVtuYW1lXSA9ICttYXBbbmFtZV07XG4gICAgICAgICAgfVxuICAgICAgICAgIGJyZWFrO1xuICAgICAgICBjYXNlIFR5cGUuU1RSSU5HOlxuICAgICAgICAgIGlmIChoYXNLZXkobmFtZSkpIHtcbiAgICAgICAgICAgIHN0YXRlW25hbWVdID0gbWFwW25hbWVdO1xuICAgICAgICAgIH1cbiAgICAgICAgICBicmVhaztcbiAgICAgICAgY2FzZSBUeXBlLkJPT0xFQU46XG4gICAgICAgICAgaWYgKGhhc0tleShuYW1lKSkge1xuICAgICAgICAgICAgc3RhdGVbbmFtZV0gPSAobWFwW25hbWVdID09PSBcImZhbHNlXCIgPyBmYWxzZSA6IHRydWUpO1xuICAgICAgICAgIH1cbiAgICAgICAgICBicmVhaztcbiAgICAgICAgY2FzZSBUeXBlLkFSUkFZX05VTUJFUjpcbiAgICAgICAgICBpZiAobmFtZSBpbiBtYXApIHtcbiAgICAgICAgICAgIHN0YXRlW25hbWVdID0gcGFyc2VBcnJheShtYXBbbmFtZV0pLm1hcChOdW1iZXIpO1xuICAgICAgICAgIH1cbiAgICAgICAgICBicmVhaztcbiAgICAgICAgY2FzZSBUeXBlLkFSUkFZX1NUUklORzpcbiAgICAgICAgICBpZiAobmFtZSBpbiBtYXApIHtcbiAgICAgICAgICAgIHN0YXRlW25hbWVdID0gcGFyc2VBcnJheShtYXBbbmFtZV0pO1xuICAgICAgICAgIH1cbiAgICAgICAgICBicmVhaztcbiAgICAgICAgZGVmYXVsdDpcbiAgICAgICAgICB0aHJvdyBFcnJvcihcIkVuY291bnRlcmVkIGFuIHVua25vd24gdHlwZSBmb3IgYSBzdGF0ZSB2YXJpYWJsZVwiKTtcbiAgICAgIH1cbiAgICB9KTtcblxuICAgIC8vIERlc2VyaWFsaXplIHN0YXRlIHByb3BlcnRpZXMgdGhhdCBjb3JyZXNwb25kIHRvIGhpZGluZyBVSSBjb250cm9scy5cbiAgICBnZXRIaWRlUHJvcHMobWFwKS5mb3JFYWNoKHByb3AgPT4ge1xuICAgICAgc3RhdGVbcHJvcF0gPSAobWFwW3Byb3BdID09PSBcInRydWVcIikgPyB0cnVlIDogZmFsc2U7XG4gICAgfSk7XG4gICAgc3RhdGUubnVtSGlkZGVuTGF5ZXJzID0gc3RhdGUubmV0d29ya1NoYXBlLmxlbmd0aDtcbiAgICBpZiAoc3RhdGUuc2VlZCA9PSBudWxsKSB7XG4gICAgICBzdGF0ZS5zZWVkID0gTWF0aC5yYW5kb20oKS50b0ZpeGVkKDUpO1xuICAgIH1cbiAgICBNYXRoLnNlZWRyYW5kb20oc3RhdGUuc2VlZCk7XG4gICAgcmV0dXJuIHN0YXRlO1xuICB9XG5cbiAgLyoqXG4gICAqIFNlcmlhbGl6ZXMgdGhlIHN0YXRlIGludG8gdGhlIHVybCBoYXNoLlxuICAgKi9cbiAgc2VyaWFsaXplKCkge1xuICAgIC8vIFNlcmlhbGl6ZSByZWd1bGFyIHByb3BlcnRpZXMuXG4gICAgbGV0IHByb3BzOiBzdHJpbmdbXSA9IFtdO1xuICAgIFN0YXRlLlBST1BTLmZvckVhY2goKHtuYW1lLCB0eXBlLCBrZXlNYXB9KSA9PiB7XG4gICAgICBsZXQgdmFsdWUgPSB0aGlzW25hbWVdO1xuICAgICAgLy8gRG9uJ3Qgc2VyaWFsaXplIG1pc3NpbmcgdmFsdWVzLlxuICAgICAgaWYgKHZhbHVlID09IG51bGwpIHtcbiAgICAgICAgcmV0dXJuO1xuICAgICAgfVxuICAgICAgaWYgKHR5cGUgPT09IFR5cGUuT0JKRUNUKSB7XG4gICAgICAgIHZhbHVlID0gZ2V0S2V5RnJvbVZhbHVlKGtleU1hcCwgdmFsdWUpO1xuICAgICAgfSBlbHNlIGlmICh0eXBlID09PSBUeXBlLkFSUkFZX05VTUJFUiB8fFxuICAgICAgICAgIHR5cGUgPT09IFR5cGUuQVJSQVlfU1RSSU5HKSB7XG4gICAgICAgIHZhbHVlID0gdmFsdWUuam9pbihcIixcIik7XG4gICAgICB9XG4gICAgICBwcm9wcy5wdXNoKGAke25hbWV9PSR7dmFsdWV9YCk7XG4gICAgfSk7XG4gICAgLy8gU2VyaWFsaXplIHByb3BlcnRpZXMgdGhhdCBjb3JyZXNwb25kIHRvIGhpZGluZyBVSSBjb250cm9scy5cbiAgICBnZXRIaWRlUHJvcHModGhpcykuZm9yRWFjaChwcm9wID0+IHtcbiAgICAgIHByb3BzLnB1c2goYCR7cHJvcH09JHt0aGlzW3Byb3BdfWApO1xuICAgIH0pO1xuICAgIHdpbmRvdy5sb2NhdGlvbi5oYXNoID0gcHJvcHMuam9pbihcIiZcIik7XG4gIH1cblxuICAvKiogUmV0dXJucyBhbGwgdGhlIGhpZGRlbiBwcm9wZXJ0aWVzLiAqL1xuICBnZXRIaWRkZW5Qcm9wcygpOiBzdHJpbmdbXSB7XG4gICAgbGV0IHJlc3VsdDogc3RyaW5nW10gPSBbXTtcbiAgICBmb3IgKGxldCBwcm9wIGluIHRoaXMpIHtcbiAgICAgIGlmIChlbmRzV2l0aChwcm9wLCBISURFX1NUQVRFX1NVRkZJWCkgJiYgdGhpc1twcm9wXSA9PT0gdHJ1ZSkge1xuICAgICAgICByZXN1bHQucHVzaChwcm9wLnJlcGxhY2UoSElERV9TVEFURV9TVUZGSVgsIFwiXCIpKTtcbiAgICAgIH1cbiAgICB9XG4gICAgcmV0dXJuIHJlc3VsdDtcbiAgfVxuXG4gIHNldEhpZGVQcm9wZXJ0eShuYW1lOiBzdHJpbmcsIGhpZGRlbjogYm9vbGVhbikge1xuICAgIHRoaXNbbmFtZSArIEhJREVfU1RBVEVfU1VGRklYXSA9IGhpZGRlbjtcbiAgfVxufVxuIl19

--- a/dist/index.html
+++ b/dist/index.html
@@ -94,10 +94,17 @@ limitations under the License.
         <label for="activations">Activation</label>
         <div class="select">
           <select id="activations">
-            <option value="relu">ReLU</option>
-            <option value="tanh">Tanh</option>
             <option value="sigmoid">Sigmoid</option>
+            <option value="tanh">Tanh</option>
+            <option value="relu">ReLU</option>
             <option value="linear">Linear</option>
+            <option value="arctan">ArcTan</option>
+            <option value="softsign">Softsign</option>
+            <option value="elu">ELU</option>
+            <option value="softplus">SoftPlus</option>
+            <option value="gaussian">Gaussian</option>
+            <option value="sin">Sinusoid</option>
+            <option value="bent">Bent Identity</option>
           </select>
         </div>
       </div>
@@ -322,7 +329,7 @@ limitations under the License.
   <article>
     <div class="l--body">
       <h2>Um, What Is a Neural Network?</h2>
-      <p>It’s a technique for building a computer program that learns from data. It is based very loosely on how we think the human brain works. First, a collection of software “neurons” are created and connected together, allowing them to send messages to each other. Next, the network is asked to solve a problem, which it attempts to do over and over, each time strengthening the connections that lead to success and diminishing those that lead to failure. For a more detailed introduction to neural networks, Michael Nielsen’s <a href="http://neuralnetworksanddeeplearning.com/index.html">Neural Networks and Deep Learning</a> is a good place to start. For more a more technical overview, try <a href="http://www.deeplearningbook.org/">Deep Learning</a> by Ian Goodfellow, Yoshua Bengio, and Aaron Courville.</p>
+      <p>It’s a technique for building a computer program that learns from data. It is based very loosely on how we think the human brain works. First, a collection of software “neurons” are created and connected together, allowing them to send messages to each other. Next, the network is asked to solve a problem, which it attempts to do over and over, each time strengthening the connections that lead to success and diminishing those that lead to failure. For a more detailed introduction to neural networks, Michael Nielsen’s <a href="http://neuralnetworksanddeeplearning.com/index.html">Neural Networks and Deep Learning</a> is a good place to start. For a more technical overview, try <a href="http://www.deeplearningbook.org/">Deep Learning</a> by Ian Goodfellow, Yoshua Bengio, and Aaron Courville.</p>
     </div>
 
     <div class="l--body">

--- a/index.html
+++ b/index.html
@@ -94,10 +94,17 @@ limitations under the License.
         <label for="activations">Activation</label>
         <div class="select">
           <select id="activations">
-            <option value="relu">ReLU</option>
-            <option value="tanh">Tanh</option>
             <option value="sigmoid">Sigmoid</option>
+            <option value="tanh">Tanh</option>
+            <option value="relu">ReLU</option>
             <option value="linear">Linear</option>
+            <option value="arctan">ArcTan</option>
+            <option value="softsign">Softsign</option>
+            <option value="elu">ELU</option>
+            <option value="softplus">SoftPlus</option>
+            <option value="gaussian">Gaussian</option>
+            <option value="sin">Sinusoid</option>
+            <option value="bent">Bent Identity</option>
           </select>
         </div>
       </div>

--- a/nn.ts
+++ b/nn.ts
@@ -109,27 +109,64 @@ export class Errors {
 
 /** Built-in activation functions */
 export class Activations {
+  public static ARCTAN: ActivationFunction = {
+    output: x => (<any>Math).atan(x),
+    der: x => 1 / (x * x + 1)
+  };
+  public static BENT: ActivationFunction = {
+    output: x => ((<any>Math).sqrt(x * x + 1) - 1) / 2 + x,
+    der: x => x / (2*(<any>Math).sqrt(x * x + 1)) + 1
+  };
+  public static ELU: ActivationFunction = {
+    output: x => x < 0 ? (<any>Math).exp(x) - 1 : x,
+    der: x => {
+      let output = Activations.ELU.output(x);
+      return x < 0 ? output + 1 : 1;
+    }
+  };
+  public static GAUSSIAN: ActivationFunction = {
+    output: x => (<any>Math).exp(-x * x),
+    der: x => {
+      let output = Activations.GAUSSIAN.output(x);
+      return -2 * x * output;
+    }
+  };
+  public static LINEAR: ActivationFunction = {
+    output: x => x,
+    der: x => 1
+  };
+  public static RELU: ActivationFunction = {
+    output: x => (<any>Math).max(0, x),
+    der: x => x <= 0 ? 0 : 1
+  };
+  public static SIGMOID: ActivationFunction = {
+    output: x => 1 / (1 + (<any>Math).exp(-x)),
+    der: x => {
+      let output = Activations.SIGMOID.output(x);
+      return output * (1 - output);
+    }
+  };
+  public static SINUSOID: ActivationFunction = {
+    output: x => (<any>Math).sin(x),
+    der: x => (<any>Math).cos(x)
+  };
+  public static SOFTPLUS: ActivationFunction = {
+    output: x => (<any>Math).log(1 + (<any>Math).exp(x)),
+    der: x => Activations.SIGMOID.output(x)
+  };
+  public static SOFTSIGN: ActivationFunction = {
+    output: x => x / (1 + (<any>Math).abs(x)),
+    der: x => {
+      let root = 1 / (1 + (<any>Math).abs(x));
+      return root * root;
+    }
+  };
   public static TANH: ActivationFunction = {
     output: x => (<any>Math).tanh(x),
     der: x => {
       let output = Activations.TANH.output(x);
       return 1 - output * output;
     }
-  };
-  public static RELU: ActivationFunction = {
-    output: x => Math.max(0, x),
-    der: x => x <= 0 ? 0 : 1
-  };
-  public static SIGMOID: ActivationFunction = {
-    output: x => 1 / (1 + Math.exp(-x)),
-    der: x => {
-      let output = Activations.SIGMOID.output(x);
-      return output * (1 - output);
-    }
-  };
-  public static LINEAR: ActivationFunction = {
-    output: x => x,
-    der: x => 1
   };
 }
 

--- a/playground.ts
+++ b/playground.ts
@@ -296,7 +296,7 @@ function makeGUI() {
 
   let activationDropdown = d3.select("#activations").on("change", function() {
     state.activation = activations[this.value];
-    reset();
+    updateActivation();
   });
   activationDropdown.property("value",
       getKeyFromValue(activations, state.activation));
@@ -893,6 +893,19 @@ export function getOutputWeights(network: nn.Node[][]): number[] {
   return weights;
 }
 
+function setOutputWeights(network: nn.Node[][], weights: number[]){
+  let idx: number = 0;
+  for (let layerIdx = 0; layerIdx < network.length - 1; layerIdx++) {
+    let currentLayer = network[layerIdx];
+    for (let i = 0; i < currentLayer.length; i++) {
+      let node = currentLayer[i];
+      for (let j = 0; j < node.outputs.length; j++) {
+        node.outputs[j].weight = weights[idx++];
+      }
+    }
+  }
+}
+
 function reset() {
   lineChart.reset();
   state.serialize();
@@ -915,6 +928,19 @@ function reset() {
   drawNetwork(network);
   updateUI(true);
 };
+
+function updateActivation() {
+  state.serialize();
+  let numInputs = constructInput(0 , 0).length;
+  let shape = [numInputs].concat(state.networkShape).concat([1]);
+  let outputActivation = (state.problem == Problem.REGRESSION) ?
+      nn.Activations.LINEAR : nn.Activations.TANH;
+  let weights = getOutputWeights(network);
+  network = nn.buildNetwork(shape, state.activation, outputActivation,
+      state.regularization, constructInputIds());
+  setOutputWeights(network, weights);
+};
+
 
 function initTutorial() {
   if (state.tutorial == null) {

--- a/state.ts
+++ b/state.ts
@@ -21,10 +21,17 @@ const HIDE_STATE_SUFFIX = "_hide";
 
 /** A map between names and activation functions. */
 export let activations: {[key: string]: nn.ActivationFunction} = {
+  "arctan": nn.Activations.ARCTAN,
+  "bent": nn.Activations.BENT,
+  "elu": nn.Activations.ELU,
+  "gaussian": nn.Activations.GAUSSIAN,
+  "linear": nn.Activations.LINEAR,
   "relu": nn.Activations.RELU,
-  "tanh": nn.Activations.TANH,
   "sigmoid": nn.Activations.SIGMOID,
-  "linear": nn.Activations.LINEAR
+  "sin": nn.Activations.SINUSOID,
+  "softplus": nn.Activations.SOFTPLUS,
+  "softsign": nn.Activations.SOFTSIGN,
+  "tanh": nn.Activations.TANH
 };
 
 /** A map between names and regularization functions. */


### PR DESCRIPTION
This PR introduces two new features.

1) I implemented some common activations listed [here](https://en.wikipedia.org/wiki/Activation_function), including: 
- ArcTan 
- Softsign
- ELU (with alpha = 1)
- SoftPlus 
- Bent Identity (This one isn't very useful. We could remove it)
- Sinusoid
- Gaussian

Not included common activation functions are: Unit Step (I couldn't get pretty results) and PReLU. 

2) Switched the default behavior to not re-initializing the weight matrix when switching between activation functions. This works well when switching between most activations, but can yield poor results when switching between functions that are more different from each other (i.e. linear and tanh). 
