### PR TITLE
Make clicking on the Regenerate button reset the state

### DIFF
--- a/playground.ts
+++ b/playground.ts
@@ -196,6 +196,7 @@ function makeGUI() {
 
   d3.select("#data-regen-button").on("click", () => {
     generateData();
+    reset();
   });
 
   let dataThumbnails = d3.selectAll("canvas[data-dataset]");


### PR DESCRIPTION
Not sure if this is intentional to have it keep state when you hit Regenerate but since changing any of the other data parameters reset the state I thought it was a bug.