### PR TITLE
Fixed link to CONTRIBUTING.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Deep playground is an interactive visualization of neural networks, written in t
 We use github issues for tracking new requests and bugs. Your feedback is highly appreciated!
 
 **If you'd like to contribute, be sure to review the [contribution
-guidelines](CONTRIBUTING).**
+guidelines](CONTRIBUTING.md).**
 
 ## Development
 


### PR DESCRIPTION
Hi, 

I was following the README and it seems the link to CONTRIBUTING.md is not apt. So this is my bit to fix that.