### PR TITLE
Fix weight line hover target style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -709,7 +709,7 @@ g.column rect {
 #network .core .link-hover {
   stroke-width: 8;
   stroke: black;
-  fill: "none";
+  fill: none;
   opacity: 0;
 }
 


### PR DESCRIPTION
A typo in the styles causes the hover target to be closed.

<img width="732" alt="screen shot 2016-10-14 at 9 44 21 am" src="https://cloud.githubusercontent.com/assets/20806/19389672/d8077a20-91f2-11e6-94dc-6ce90bd80219.png">
<img width="715" alt="screen shot 2016-10-14 at 9 44 33 am" src="https://cloud.githubusercontent.com/assets/20806/19389674/da81e006-91f2-11e6-9e59-b5acea8216a6.png">
