### PR TITLE
Two more regression samples & fix bug on thumbnail upside down

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,9 @@ limitations under the License.
           <div class="dataset" title="Maximum">
             <canvas class="data-thumbnail" data-regDataset="reg-maximum"></canvas>
           </div>
+          <div class="dataset" title="ArgMax">
+            <canvas class="data-thumbnail" data-regDataset="reg-argmax"></canvas>
+          </div>
           <div class="dataset" title="Plane">
             <canvas class="data-thumbnail" data-regDataset="reg-plane"></canvas>
           </div>

--- a/index.html
+++ b/index.html
@@ -163,6 +163,9 @@ limitations under the License.
           <div class="dataset" title="Spiral">
             <canvas class="data-thumbnail" data-dataset="spiral"></canvas>
           </div>
+          <div class="dataset" title="Maximum">
+            <canvas class="data-thumbnail" data-regDataset="reg-maximum"></canvas>
+          </div>
           <div class="dataset" title="Plane">
             <canvas class="data-thumbnail" data-regDataset="reg-plane"></canvas>
           </div>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "http-server": "^0.9.0"
   },
   "dependencies": {
+    "browserify": "^16.2.0",
     "catw": "^1.0.1",
     "d3": "^3.5.16",
     "material-design-lite": "^1.1.3",

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -70,6 +70,24 @@ export function classifyTwoGaussData(numSamples: number, noise: number):
   return points;
 }
 
+export function regressArgMax(numSamples: number, noise: number):
+  Example2D[] {
+  let radius = 6;
+  let labelScale = d3.scale.linear()
+    .domain([-10, 10])
+    .range([-1, 1]);
+  let getLabel = (x, y) => Math.max(x,y)==x?0:1;
+
+  let points: Example2D[] = [];
+  for (let i = 0; i < numSamples; i++) {
+    let x = randUniform(-radius, radius);
+    let y = randUniform(-radius, radius);
+    let label = getLabel(x , y);
+    points.push({x, y, label});
+  }
+  return points;
+}
+
 export function regressMaximum(numSamples: number, noise: number):
   Example2D[] {
   let radius = 6;

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -70,6 +70,24 @@ export function classifyTwoGaussData(numSamples: number, noise: number):
   return points;
 }
 
+export function regressMaximum(numSamples: number, noise: number):
+  Example2D[] {
+  let radius = 6;
+  let labelScale = d3.scale.linear()
+    .domain([-10, 10])
+    .range([-1, 1]); 
+  let getLabel = (x, y) => Math.max(x,y);
+
+  let points: Example2D[] = [];
+  for (let i = 0; i < numSamples; i++) {
+    let x = randUniform(-radius, radius);
+    let y = randUniform(-radius, radius);
+    let label = getLabel(x , y);
+    points.push({x, y, label});
+  }
+  return points;
+}
+
 export function regressPlane(numSamples: number, noise: number):
   Example2D[] {
   let radius = 6;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -999,7 +999,7 @@ function drawDatasetThumbnails() {
     let data = dataGenerator(200, 0);
     data.forEach(function(d) {
       context.fillStyle = colorScale(d.label);
-      context.fillRect(w * (d.x + 6) / 12, h * (d.y + 6) / 12, 4, 4);
+      context.fillRect(w * (d.x + 6) / 12, h - h * (d.y + 6) / 12 - 4, 4, 4);
     });
     d3.select(canvas.parentNode).style("display", null);
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -44,6 +44,7 @@ export let datasets: {[key: string]: dataset.DataGenerator} = {
 
 /** A map between dataset names and functions that generate regression data. */
 export let regDatasets: {[key: string]: dataset.DataGenerator} = {
+  "reg-maximum": dataset.regressMaximum,
   "reg-plane": dataset.regressPlane,
   "reg-gauss": dataset.regressGaussian
 };

--- a/src/state.ts
+++ b/src/state.ts
@@ -45,6 +45,7 @@ export let datasets: {[key: string]: dataset.DataGenerator} = {
 /** A map between dataset names and functions that generate regression data. */
 export let regDatasets: {[key: string]: dataset.DataGenerator} = {
   "reg-maximum": dataset.regressMaximum,
+  "reg-argmax": dataset.regressArgMax,
   "reg-plane": dataset.regressPlane,
   "reg-gauss": dataset.regressGaussian
 };


### PR DESCRIPTION
2 more reg samples :
- Maximum
- RegMax

Thumbnail were also upside down ! The problem is thumbnails and network are not generated the same way (network comes from svg data). The easiest was to fix the renderThumbnail function.