### PR TITLE
Fix data point locations in data thumbnails

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1000,7 +1000,7 @@ function drawDatasetThumbnails() {
     let data = dataGenerator(200, 0);
     data.forEach(function(d) {
       context.fillStyle = colorScale(d.label);
-      context.fillRect(w * (d.x + 6) / 12, h * (d.y + 6) / 12, 4, 4);
+      context.fillRect(w * (d.x + 6) / 12, h * (-d.y + 6) / 12, 4, 4);
     });
     d3.select(canvas.parentNode).style("display", null);
   }


### PR DESCRIPTION
The dataset thumbnails were upside down because the thumbnail canvas' coordinate system moves positively from top to bottom whereas the data point coordinates move negatively from top to bottom. To convert data point coordinates to canvas coordinates the y-coordinate must be negated.