### PR TITLE
Add dataset to illustrate overfitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,9 @@ limitations under the License.
           <div class="dataset" title="Spiral">
             <canvas class="data-thumbnail" data-dataset="spiral"></canvas>
           </div>
+          <div class="dataset" title="Diagonal">
+            <canvas class="data-thumbnail" data-dataset="diagonal"></canvas>
+          </div> 
           <div class="dataset" title="Plane">
             <canvas class="data-thumbnail" data-regDataset="reg-plane"></canvas>
           </div>

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -140,8 +140,9 @@ export function classifySpiralData(numSamples: number, noise: number):
 
   function genSpiral(deltaT: number, label: number) {
     for (let i = 0; i < n; i++) {
-      let r = i / n * 5;
-      let t = 1.75 * i / n * 2 * Math.PI + deltaT;
+      let j = randUniform(0, n);
+      let r = j / n * 5;
+      let t = 1.75 * j / n * 2 * Math.PI + deltaT;
       let x = r * Math.sin(t) + randUniform(-1, 1) * noise;
       let y = r * Math.cos(t) + randUniform(-1, 1) * noise;
       points.push({x, y, label});

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -207,6 +207,65 @@ export function classifyXORData(numSamples: number, noise: number):
   return points;
 }
 
+export function classifyDiagonalTrainData(numSamples: number, noise: number):
+    Example2D[] {
+  function getDiagonalLabel(p: Point) { return p.y <= -p.x ? 1 : -1; }
+
+  let points: Example2D[] = [];
+  let numNoiseSamples = numSamples * noise;
+  let numNegSamples  = (numSamples - numNoiseSamples) / 2;
+  let numPosSamples = numNegSamples;
+  let padding = 0.3;
+
+  // Generate the negative examples in the upper triangle.
+  for (let i = 0; i < numNegSamples; i++) {
+    let x = randUniform(-5, 5);
+    let y = randUniform(-x, 5);
+    x += y > -x ? padding : -padding; // pad the diagonal
+    let label = -1;
+    points.push({x, y, label});
+  }
+
+  // Generate the positive examples as a subset of the lower triangle.
+  for (let i = 0; i < numPosSamples; i ++) {
+    let x = randUniform(-5, 2);
+    let y = randUniform(-5, Math.min(-x, 2));
+    x += y > -x ? padding : -padding; // pad the diagonal
+    let label = 1;
+    points.push({x, y, label});
+  }
+
+  // Generate noise data points across entire plane.
+  for (let i = 0; i < numNoiseSamples / 2; i++) {
+    let x = randUniform(-5, 5);
+    let y = randUniform(-5, 5);
+    let noiseX = randUniform(-5, 5);
+    let noiseY = randUniform(-5, 5);
+    let label = getDiagonalLabel({x: x + noiseX, y: y + noiseY});
+    points.push({x, y, label});
+  }
+
+  return points;
+}
+
+export function classifyDiagonalTestData(numSamples: number, noise: number):
+    Example2D[] {
+  function getDiagonalLabel(p: Point) { return p.y <= -p.x ? 1 : -1; }
+
+  // Generate negative data below the diagonal and positive data above.
+  let points: Example2D[] = [];
+  for (let i = 0; i < numSamples; i++) {
+    let x = randUniform(-5, 5);
+    let y = randUniform(-5, 5);
+    let noiseX = randUniform(-5, 5) * noise;
+    let noiseY = randUniform(-5, 5) * noise;
+    let label = getDiagonalLabel({x: x + noiseX, y: y + noiseY});
+    points.push({x, y, label});
+  }
+  return points;
+}
+
+
 /**
  * Returns a sample from a uniform [a, b] distribution.
  * Uses the seedrandom library as the random generator.

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1000,7 +1000,7 @@ function drawDatasetThumbnails() {
     let data = dataGenerator(200, 0);
     data.forEach(function(d) {
       context.fillStyle = colorScale(d.label);
-      context.fillRect(w * (d.x + 6) / 12, h * (d.y + 6) / 12, 4, 4);
+      context.fillRect(w * (d.x + 6) / 12, h * (-d.y + 6) / 12, 4, 4);
     });
     d3.select(canvas.parentNode).style("display", null);
   }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -111,7 +111,7 @@ class Player {
 
   onPlayPause(callback: (isPlaying: boolean) => void) {
     this.callback = callback;
-  }
+  };
 
   play() {
     this.pause();
@@ -220,7 +220,11 @@ function makeGUI() {
     reset();
   });
 
+  console.log("SUP");
+  console.log(datasets);
+  console.log(state.dataset);
   let datasetKey = getKeyFromValue(datasets, state.dataset);
+  console.log(datasetKey);
   // Select the dataset according to the current state.
   d3.select(`canvas[data-dataset=${datasetKey}]`)
     .classed("selected", true);
@@ -1010,7 +1014,7 @@ function drawDatasetThumbnails() {
     for (let dataset in datasets) {
       let canvas: any =
           document.querySelector(`canvas[data-dataset=${dataset}]`);
-      let dataGenerator = datasets[dataset];
+      let dataGenerator = datasets[dataset].trainGenerator;
       renderThumbnail(canvas, dataGenerator);
     }
   }
@@ -1018,7 +1022,7 @@ function drawDatasetThumbnails() {
     for (let regDataset in regDatasets) {
       let canvas: any =
           document.querySelector(`canvas[data-regDataset=${regDataset}]`);
-      let dataGenerator = regDatasets[regDataset];
+      let dataGenerator = regDatasets[regDataset].trainGenerator;
       renderThumbnail(canvas, dataGenerator);
     }
   }
@@ -1076,13 +1080,10 @@ function generateData(firstTime = false) {
       NUM_SAMPLES_REGRESS : NUM_SAMPLES_CLASSIFY;
   let generator = state.problem === Problem.CLASSIFICATION ?
       state.dataset : state.regDataset;
-  let data = generator(numSamples, state.noise / 100);
-  // Shuffle the data in-place.
-  shuffle(data);
-  // Split into train and test data.
-  let splitIndex = Math.floor(data.length * state.percTrainData / 100);
-  trainData = data.slice(0, splitIndex);
-  testData = data.slice(splitIndex);
+  let numTrainSamples = numSamples * state.percTrainData / 100;
+  let numTestSamples = numSamples * (100 - state.percTrainData) / 100;
+  trainData = generator.trainGenerator(numTrainSamples, state.noise / 100);
+  testData = generator.testGenerator(numTestSamples, state.noise / 100);
   heatMap.updatePoints(trainData);
   heatMap.updateTestPoints(state.showTestData ? testData : []);
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -34,24 +34,51 @@ export let regularizations: {[key: string]: nn.RegularizationFunction} = {
   "L2": nn.RegularizationFunction.L2
 };
 
-/** A map between dataset names and functions that generate classification data. */
-export let datasets: {[key: string]: dataset.DataGenerator} = {
-  "circle": dataset.classifyCircleData,
-  "xor": dataset.classifyXORData,
-  "gauss": dataset.classifyTwoGaussData,
-  "spiral": dataset.classifySpiralData,
+/** DatasetGenerator class contains generator functions for training and
+ *  testing data. */
+class DatasetGenerator {
+  trainGenerator: dataset.DataGenerator;
+  testGenerator: dataset.DataGenerator;
+
+  // if only one generator is supplied it is used for training and testing
+  constructor(trainGenerator: dataset.DataGenerator,
+              testGenerator ?: dataset.DataGenerator) {
+    this.trainGenerator = trainGenerator;
+    this.testGenerator = testGenerator == null ? trainGenerator : testGenerator;
+  }
+
+   equals(other: DatasetGenerator) {
+     return (this.trainGenerator === other.trainGenerator &&
+             this.testGenerator === other.testGenerator);
+   }
+}
+
+/** A map between dataset names and the DatasetGenerator that contains
+ *  functions to geneterate classification data. */
+export let datasets: {[key: string]: DatasetGenerator} = {
+  "circle": new DatasetGenerator(dataset.classifyCircleData),
+  "xor": new DatasetGenerator(dataset.classifyXORData),
+  "gauss": new DatasetGenerator(dataset.classifyTwoGaussData),
+  "spiral": new DatasetGenerator(dataset.classifySpiralData),
 };
 
-/** A map between dataset names and functions that generate regression data. */
-export let regDatasets: {[key: string]: dataset.DataGenerator} = {
-  "reg-plane": dataset.regressPlane,
-  "reg-gauss": dataset.regressGaussian
+/** A map between dataset names and the DatasetGenerator that contains
+ *  functions to geneterate regression data. */
+export let regDatasets: {[key: string]: DatasetGenerator} = {
+  "reg-plane": new DatasetGenerator(dataset.regressPlane),
+  "reg-gauss": new DatasetGenerator(dataset.regressGaussian),
 };
 
 export function getKeyFromValue(obj: any, value: any): string {
   for (let key in obj) {
-    if (obj[key] === value) {
-      return key;
+    if (value instanceof DatasetGenerator) {
+      if (obj[key].equals(value)) {
+        return key;
+      }
+    } else {
+      if (obj[key] === value) {
+        return key;
+      }
     }
   }
   return undefined;
@@ -98,7 +125,7 @@ export interface Property {
   name: string;
   type: Type;
   keyMap?: {[key: string]: any};
-};
+}
 
 // Add the GUI state.
 export class State {
@@ -160,8 +187,8 @@ export class State {
   sinX = false;
   cosY = false;
   sinY = false;
-  dataset: dataset.DataGenerator = dataset.classifyCircleData;
-  regDataset: dataset.DataGenerator = dataset.regressPlane;
+  dataset: DatasetGenerator = new DatasetGenerator(dataset.classifyCircleData);
+  regDataset: DatasetGenerator = new DatasetGenerator(dataset.regressPlane);
   seed: string;
 
   /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -60,6 +60,7 @@ export let datasets: {[key: string]: DatasetGenerator} = {
   "xor": new DatasetGenerator(dataset.classifyXORData),
   "gauss": new DatasetGenerator(dataset.classifyTwoGaussData),
   "spiral": new DatasetGenerator(dataset.classifySpiralData),
+  "diagonal": new DatasetGenerator(dataset.classifyDiagonalTrainData, dataset.classifyDiagonalTestData),
 };
 
 /** A map between dataset names and the DatasetGenerator that contains


### PR DESCRIPTION
This PR adds a dataset to exhibit the concept of overfitting. The dataset is linearly separable along the main diagonal, but its positive training samples only span a subset of the area under the diagonal while its positive testing samples span the _entire_ area under the diagonal. Deep models with more complex functions will overfit the training data to minimize training loss while increasing the test loss, which illustrates overfitting. 

Previously this was not possible as all the current datasets have testing and training samples drawn from the same distribution. To accommodate this type of dataset this PR refactors the way data generators are stored to include separate training and testing generators. 

<img width="293" alt="overfitting_dataset_example" src="https://user-images.githubusercontent.com/17207428/51810414-aa963700-2275-11e9-94d7-a952a01bc11d.png">
