### PR TITLE
Adding custom Datapoints to canvas.

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,11 +275,11 @@ limitations under the License.
       </div>
       <div id="heatmap"></div>
       <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-        <input type="radio" name="color-choose" id="select-orange" value="orange" checked>
+        <input type="radio" name="color-choose" id="select-orange" value="1" checked>
         <span class="mdl-checkbox__label label">Orange</span>
       </label>
       <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-        <input type="radio" name="color-choose" id="select-blue" value="blue">
+        <input type="radio" name="color-choose" id="select-blue" value="-1">
         <span class="mdl-checkbox__label label">Blue</span>
       </label>
       <div style="float:left;margin-top:20px">

--- a/index.html
+++ b/index.html
@@ -274,14 +274,19 @@ limitations under the License.
         <div id="linechart"></div>
       </div>
       <div id="heatmap"></div>
-      <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-        <input type="radio" name="color-choose" id="select-orange" value="1" checked>
-        <span class="mdl-checkbox__label label">Orange</span>
-      </label>
-      <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-        <input type="radio" name="color-choose" id="select-blue" value="-1">
-        <span class="mdl-checkbox__label label">Blue</span>
-      </label>
+      <div id="select-platform">
+          <div class="label">
+              Select color that you would like to paint with.
+          </div>
+          <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+            <input type="radio" name="color-choose" id="select-orange" value="1" checked>
+            <span class="mdl-checkbox__label label">Orange</span>
+          </label>
+          <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+            <input type="radio" name="color-choose" id="select-blue" value="-1">
+            <span class="mdl-checkbox__label label">Blue</span>
+          </label>
+      </div>
       <div style="float:left;margin-top:20px">
         <div style="display:flex; align-items:center;">
           <!-- Gradient color scale -->

--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@ limitations under the License.
         <div id="linechart"></div>
       </div>
       <div id="heatmap"></div>
-      <div id="select-platform">
+      <div id="select-platform" class="ui-paintPlatform">
           <div class="label">
               Select color that you would like to paint with.
           </div>

--- a/index.html
+++ b/index.html
@@ -274,9 +274,16 @@ limitations under the License.
         <div id="linechart"></div>
       </div>
       <div id="heatmap"></div>
+      <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+        <input type="radio" name="color-choose" id="select-orange" value="orange" checked>
+        <span class="mdl-checkbox__label label">Orange</span>
+      </label>
+      <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+        <input type="radio" name="color-choose" id="select-blue" value="blue">
+        <span class="mdl-checkbox__label label">Blue</span>
+      </label>
       <div style="float:left;margin-top:20px">
         <div style="display:flex; align-items:center;">
-
           <!-- Gradient color scale -->
           <div class="label" style="width:105px; margin-right: 10px">
             Colors shows data, neuron and weight values.

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -88,6 +88,10 @@ export class HeatMap {
         position: "relative",
         top: `-${padding}px`,
         left: `-${padding}px`
+      }).on("click" , function() {
+        const [x, y]= d3.mouse(this)
+        console.log(x)
+        console.log(y)
       });
     this.canvas = container.append("canvas")
       .attr("width", numSamples)
@@ -97,7 +101,7 @@ export class HeatMap {
       .style("position", "absolute")
       .style("top", `${padding}px`)
       .style("left", `${padding}px`);
-
+  
     if (!this.settings.noSvg) {
       this.svg = container.append("svg").attr({
           "width": width,

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -155,7 +155,6 @@ export class HeatMap {
     if (this.settings.noSvg) {
       throw Error("Can't add points since noSvg=true");
     }
-    console.log("GOT HERE ONCE AT LEAST")
     this.points = points.map(point => point);
     this.updateCircles(this.svg.select("g.train"), points);
   }

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -41,6 +41,7 @@ export class HeatMap {
   private color;
   private canvas;
   private svg;
+  private points: Example2D[];
 
   constructor(
       width: number, numSamples: number, xDomain: [number, number],
@@ -88,11 +89,7 @@ export class HeatMap {
         position: "relative",
         top: `-${padding}px`,
         left: `-${padding}px`
-      }).on("click" , function() {
-        const [x, y]= d3.mouse(this)
-        console.log(x)
-        console.log(y)
-      });
+      })
     this.canvas = container.append("canvas")
       .attr("width", numSamples)
       .attr("height", numSamples)
@@ -146,10 +143,20 @@ export class HeatMap {
     this.updateCircles(this.svg.select("g.test"), points);
   }
 
+  addPointToCanvas(point: Example2D): void {
+    if (this.settings.noSvg) {
+      throw Error("Can't add points since noSvg=true");
+    }
+    this.points.push(point)
+    this.updateCircles(this.svg.select("g.train"), this.points);
+  }
+
   updatePoints(points: Example2D[]): void {
     if (this.settings.noSvg) {
       throw Error("Can't add points since noSvg=true");
     }
+    console.log("GOT HERE ONCE AT LEAST")
+    this.points = points.map(point => point);
     this.updateCircles(this.svg.select("g.train"), points);
   }
 

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -41,7 +41,6 @@ export class HeatMap {
   private color;
   private canvas;
   private svg;
-  private points: Example2D[];
 
   constructor(
       width: number, numSamples: number, xDomain: [number, number],
@@ -143,19 +142,10 @@ export class HeatMap {
     this.updateCircles(this.svg.select("g.test"), points);
   }
 
-  addPointToCanvas(point: Example2D): void {
-    if (this.settings.noSvg) {
-      throw Error("Can't add points since noSvg=true");
-    }
-    this.points.push(point)
-    this.updateCircles(this.svg.select("g.train"), this.points);
-  }
-
   updatePoints(points: Example2D[]): void {
     if (this.settings.noSvg) {
       throw Error("Can't add points since noSvg=true");
     }
-    this.points = points.map(point => point);
     this.updateCircles(this.svg.select("g.train"), points);
   }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -97,7 +97,6 @@ class Player {
 
   /** Plays/pauses the player. */
   playOrPause() {
-    debugger;
     if (this.isPlaying) {
       this.isPlaying = false;
       this.pause();
@@ -275,8 +274,7 @@ function makeGUI() {
     userHasInteracted()
   });
 
-
-  d3.select("#heatmap").on("click", function() {
+  let dragBehavior = d3.behavior.drag().on("drag", function() {
         let [x, y] = d3.mouse(this)
         const label = state.editColor
         const padding = 20
@@ -289,6 +287,8 @@ function makeGUI() {
         state.trainData.push({x, y, label})
         heatMap.updatePoints(state.trainData);
   });
+
+  d3.select("#heatmap").call(dragBehavior);
 
   let showTestData = d3.select("#show-test-data").on("change", function() {
     state.showTestData = this.checked;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -264,16 +264,30 @@ function makeGUI() {
     reset();
   });
 
-  let selectOrangeEdit = d3.select("#select-orange").on("change", function() {
-    state.editColor = this.checked ? this.value : "blue"
+  d3.select("#select-orange").on("change", function() {
+    state.editColor = this.checked ? -1 : 1
     state.serialize()
     userHasInteracted()
   });
 
-  let selectBlueEdit = d3.select("#select-blue").on("change", function() {
-    state.editColor = this.checked ? this.value : "orange"
+  d3.select("#select-blue").on("change", function() {
+    state.editColor = this.checked ? 1 : -1
     state.serialize()
     userHasInteracted()
+  });
+
+
+  d3.select("#heatmap").on("click", function() {
+        let [x, y] = d3.mouse(this)
+        const label = state.editColor
+        const padding = 20
+        const maxScale = 5.0
+        const factor = 23.07
+        x -= padding
+        y -= padding
+        x = x/factor - maxScale
+        y = maxScale - y/factor
+        heatMap.addPointToCanvas({x, y, label})
   });
 
   let showTestData = d3.select("#show-test-data").on("change", function() {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -274,18 +274,21 @@ function makeGUI() {
     userHasInteracted()
   });
 
+  // On drag, we want to paint our canvas with the dots.
   let dragBehavior = d3.behavior.drag().on("drag", function() {
-        let [x, y] = d3.mouse(this)
-        const label = state.editColor
-        const padding = 20
-        const maxScale = 5.0
-        const factor = 23.07
-        x -= padding
-        y -= padding
-        x = x/factor - maxScale
-        y = maxScale - y/factor
-        state.trainData.push({x, y, label})
-        heatMap.updatePoints(state.trainData);
+    if(state.problem === Problem.CLASSIFICATION) {
+      let [x, y] = d3.mouse(this)
+      const label = state.editColor
+      const padding = 20
+      const maxScale = 5.0
+      const factor = 23.07
+      x -= padding
+      y -= padding
+      x = x/factor - maxScale
+      y = maxScale - y/factor
+      state.trainData.push({x, y, label})
+      heatMap.updatePoints(state.trainData);
+    }
   });
 
   d3.select("#heatmap").call(dragBehavior);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -287,6 +287,7 @@ function makeGUI() {
         y -= padding
         x = x/factor - maxScale
         y = maxScale - y/factor
+        console.log(label)
         heatMap.addPointToCanvas({x, y, label})
   });
 
@@ -975,6 +976,10 @@ function reset(onStartup=false) {
   d3.select("#layers-label").text("Hidden layer" + suffix);
   d3.select("#num-layers").text(state.numHiddenLayers);
 
+  // Correct radio button on reset
+  let radioColor = state.editColor === - 1 ? "#select-orange" : "#select-blue";
+  d3.select(radioColor).attr("checked", "checked")
+  
   // Make a simple network.
   iter = 0;
   let numInputs = constructInput(0 , 0).length;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -88,6 +88,7 @@ let HIDABLE_CONTROLS = [
   ["Noise level", "noise"],
   ["Batch size", "batchSize"],
   ["# of hidden layers", "numHiddenLayers"],
+  ["Paint Platform", "paintPlatform"],
 ];
 
 class Player {
@@ -277,12 +278,13 @@ function makeGUI() {
 
   // On drag, we want to paint our canvas with the dots.
   let dragBehavior = d3.behavior.drag().on("drag", function() {
-    if(state.problem === Problem.CLASSIFICATION) {
+    let isVisible = d3.select("#select-platform").style("display") === "block"
+    if(state.problem === Problem.CLASSIFICATION && isVisible) {
       let [x, y] = d3.mouse(this)
-      const label = state.editColor
-      const padding = 20
-      const maxScale = 5.0
-      const factor = 23.07
+      let label = state.editColor
+      let padding = 20
+      let maxScale = 5.0
+      let factor = 23.07
       x -= padding
       y -= padding
       x = x/factor - maxScale
@@ -981,7 +983,6 @@ function reset(onStartup=false) {
   d3.select("#num-layers").text(state.numHiddenLayers);
 
   togglePaintSelection()
-
   // Correct radio button on reset
   let radioColor = state.editColor === - 1 ? "#select-orange" : "#select-blue";
   d3.select(radioColor).attr("checked", "checked")
@@ -1102,8 +1103,8 @@ function hideControls() {
 }
 
 function togglePaintSelection() {
-  let visiblity = state.problem === Problem.CLASSIFICATION ? "visible" : "hidden"
-  d3.select("#select-platform").style("visibility", visiblity);
+  let visiblity = state.problem === Problem.CLASSIFICATION ? "" : "none"
+  d3.select("#select-platform").style("display", visiblity);
 }
 
 function generateData(firstTime = false) {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -264,6 +264,18 @@ function makeGUI() {
     reset();
   });
 
+  let selectOrangeEdit = d3.select("#select-orange").on("change", function() {
+    state.editColor = this.checked ? this.value : "blue"
+    state.serialize()
+    userHasInteracted()
+  });
+
+  let selectBlueEdit = d3.select("#select-blue").on("change", function() {
+    state.editColor = this.checked ? this.value : "orange"
+    state.serialize()
+    userHasInteracted()
+  });
+
   let showTestData = d3.select("#show-test-data").on("change", function() {
     state.showTestData = this.checked;
     state.serialize();

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -262,6 +262,7 @@ function makeGUI() {
     reset();
   });
 
+  // For changing state on different selections
   d3.select("#select-orange").on("change", function() {
     state.editColor = this.checked ? -1 : 1
     state.serialize()
@@ -384,6 +385,7 @@ function makeGUI() {
 
   let problem = d3.select("#problem").on("change", function() {
     state.problem = problems[this.value];
+    togglePaintSelection();
     generateData();
     drawDatasetThumbnails();
     parametersChanged = true;
@@ -978,10 +980,12 @@ function reset(onStartup=false) {
   d3.select("#layers-label").text("Hidden layer" + suffix);
   d3.select("#num-layers").text(state.numHiddenLayers);
 
+  togglePaintSelection()
+
   // Correct radio button on reset
   let radioColor = state.editColor === - 1 ? "#select-orange" : "#select-blue";
   d3.select(radioColor).attr("checked", "checked")
-  
+
   // Make a simple network.
   iter = 0;
   let numInputs = constructInput(0 , 0).length;
@@ -1095,6 +1099,11 @@ function hideControls() {
   });
   d3.select(".hide-controls-link")
     .attr("href", window.location.href);
+}
+
+function togglePaintSelection() {
+  let visiblity = state.problem === Problem.CLASSIFICATION ? "visible" : "hidden"
+  d3.select("#select-platform").style("visibility", visiblity);
 }
 
 function generateData(firstTime = false) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -130,7 +130,8 @@ export class State {
     {name: "tutorial", type: Type.STRING},
     {name: "problem", type: Type.OBJECT, keyMap: problems},
     {name: "initZero", type: Type.BOOLEAN},
-    {name: "hideText", type: Type.BOOLEAN}
+    {name: "hideText", type: Type.BOOLEAN},
+    {name: "editColor", type: Type.STRING}
   ];
 
   [key: string]: any;

--- a/src/state.ts
+++ b/src/state.ts
@@ -131,7 +131,7 @@ export class State {
     {name: "problem", type: Type.OBJECT, keyMap: problems},
     {name: "initZero", type: Type.BOOLEAN},
     {name: "hideText", type: Type.BOOLEAN},
-    {name: "editColor", type: Type.STRING}
+    {name: "editColor", type: Type.NUMBER}
   ];
 
   [key: string]: any;
@@ -161,6 +161,7 @@ export class State {
   sinX = false;
   cosY = false;
   sinY = false;
+  editColor = -1;
   dataset: dataset.DataGenerator = dataset.classifyCircleData;
   regDataset: dataset.DataGenerator = dataset.regressPlane;
   seed: string;

--- a/src/state.ts
+++ b/src/state.ts
@@ -164,6 +164,8 @@ export class State {
   editColor = -1;
   dataset: dataset.DataGenerator = dataset.classifyCircleData;
   regDataset: dataset.DataGenerator = dataset.regressPlane;
+  trainData: dataset.Example2D[] = [];
+  testData: dataset.Example2D[] = [];
   seed: string;
 
   /**


### PR DESCRIPTION
You can now add custom datapoints to the canvas by clicking and dragging along the image. Has a couple of radio buttons to select which color datapoint you would like to add. This only works in Classification mode. On Regression mode, the app works the same and the radio buttons are hidden. The radio buttons can also be hidden via the checkbox section. The new custom datapoints are processed by the neural network when the algorithm is run.