### PR TITLE
add sine activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@ limitations under the License.
             <option value="tanh">Tanh</option>
             <option value="sigmoid">Sigmoid</option>
             <option value="linear">Linear</option>
+            <option value="sine">Sine</option>
           </select>
         </div>
       </div>

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -134,6 +134,10 @@ export class Activations {
     output: x => x,
     der: x => 1
   };
+  public static SINE: ActivationFunction = {
+    output: x => (Math as any).sin(x),
+    der: x => (Math as any).cos(x)
+  };
 }
 
 /** Build-in regularization functions */

--- a/src/state.ts
+++ b/src/state.ts
@@ -24,7 +24,8 @@ export let activations: {[key: string]: nn.ActivationFunction} = {
   "relu": nn.Activations.RELU,
   "tanh": nn.Activations.TANH,
   "sigmoid": nn.Activations.SIGMOID,
-  "linear": nn.Activations.LINEAR
+  "linear": nn.Activations.LINEAR,
+  "sine": nn.Activations.SINE
 };
 
 /** A map between names and regularization functions. */


### PR DESCRIPTION
Dear Playground Maintainers,

I would like to propose adding the sine activation to the playground.

This addition has significantly helped me develop an intuition behind the recently published "SIREN" paper (Implicit Neural Representations with Periodic Activation Functions by Vincent Sitzmann, Julien N. P. Martel, et al.), despite my lack of formal training in signal processing and related fields. For example, playing with this feature makes it apparent how NNs using the sine activation can use fewer neurons to represent transformations from coordinates to pixels (compared to the other activation functions in the playground). It helps to be able to visualize the relationships between the frequency of the signals in relation to the weights, biases, and learning rate. I also now have a better understanding how several failure modes develop.

I can appreciate not wanting to overwhelm users with too many choices of activation function. I think an exception should be made in this case since the behavior of the sine activation is sufficiently different from the others and is increasingly relevant in neural representation research. But don't take my word for it, try it out for yourself in [this fork](https://dcato98.github.io/playground/#activation=sine)!

I hope you will consider adding this feature!

All the best,
David