### PR TITLE
allow on-the-fly regularization changes

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -341,7 +341,8 @@ function makeGUI() {
       function() {
     state.regularization = regularizations[this.value];
     parametersChanged = true;
-    reset();
+    state.serialize();
+    userHasInteracted();
   });
   regularDropdown.property("value",
       getKeyFromValue(regularizations, state.regularization));
@@ -349,7 +350,8 @@ function makeGUI() {
   let regularRate = d3.select("#regularRate").on("change", function() {
     state.regularizationRate = +this.value;
     parametersChanged = true;
-    reset();
+    state.serialize();
+    userHasInteracted();
   });
   regularRate.property("value", state.regularizationRate);
 
@@ -913,7 +915,7 @@ function oneStep(): void {
     nn.forwardProp(network, input);
     nn.backProp(network, point.label, nn.Errors.SQUARE);
     if ((i + 1) % state.batchSize === 0) {
-      nn.updateWeights(network, state.learningRate, state.regularizationRate);
+      nn.updateWeights(network, state.learningRate, state.regularization, state.regularizationRate);
     }
   });
   // Compute the loss.
@@ -956,7 +958,7 @@ function reset(onStartup=false) {
   let outputActivation = (state.problem === Problem.REGRESSION) ?
       nn.Activations.LINEAR : nn.Activations.TANH;
   network = nn.buildNetwork(shape, state.activation, outputActivation,
-      state.regularization, constructInputIds(), state.initZero);
+      constructInputIds(), state.initZero);
   lossTrain = getLoss(network, trainData);
   lossTest = getLoss(network, testData);
   drawNetwork(network);


### PR DESCRIPTION
Dear Playground Maintainers,

This PR allows the user to change regularization on-the-fly. Other users have experienced difficulty getting regularization to do anything useful (e.g. #94) In my experiments with the playground, there seems to typically be an early failure-mode for regularization above the minimum 1e-3 for a wide range of initializations. Allowing changes to regularization on-the-fly enables cranking up regularization as high as 0.1 (occasionally 0.3), but only after letting the network find a stable regime.

To me this feature is a win-win since, being hidden from the user, it adds no complexity to the project and yet it allows for more experimentation by the curious user, who is now able to explore effective uses of L1 and L2 regularization. I have found that playing with on-the-fly regularization has led me to a much more intuitive understanding of how L1 and L2 "push" the weights towards sparse and distributed representations, respectively.

I hope you will consider adding this feature! 

All the best,
David