### PR TITLE
perf: improve constructInput's efficiency

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -896,14 +896,10 @@ function constructInputIds(): string[] {
   return result;
 }
 
+const inputNames = Object.keys(INPUTS);
+
 function constructInput(x: number, y: number): number[] {
-  let input: number[] = [];
-  for (let inputName in INPUTS) {
-    if (state[inputName]) {
-      input.push(INPUTS[inputName].f(x, y));
-    }
-  }
-  return input;
+  return inputNames.filter(inputName => state[inputName]).map(inputName => INPUTS[inputName].f(x, y));
 }
 
 function oneStep(): void {


### PR DESCRIPTION
## Change
Reduced the `constructInput`'s execution time from thounds of ms to less than 10 ms.

## How to test 

### The original version

- `yarn start` to run playground locally, visit [This link](http://localhost:5000/#activation=sigmoid&batchSize=1&dataset=xor&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=2&seed=0.59882&showTestData=true&discretize=false&percTrainData=90&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false) to train a XOR classification. 
- F12 to open the developer tool and start profiling in the Performance pane: 
![image](https://user-images.githubusercontent.com/3367820/117440546-c7e30100-af66-11eb-8bae-03e795330f52.png)
- Profile for 20 seconds
- Check the execution time in Sources pane, you can see `constructInput`'s time cost is above thounds of ms. 
![image](https://user-images.githubusercontent.com/3367820/117440698-f9f46300-af66-11eb-9fdf-329e8b26c8ff.png)
- I tested it for several times, sometimes it costs more than 2000 ms

### The changed version
- Save steps as above, profile for 20s and check the time costs in the Sources pane, you can see the execution time of `constructInput` has been reduced to less 10 ms.
![image](https://user-images.githubusercontent.com/3367820/117440905-4475df80-af67-11eb-9d3d-18c8000329be.png)


