### PR TITLE
Flip thumbnails in y, closes #76

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1000,7 +1000,7 @@ function drawDatasetThumbnails() {
     let data = dataGenerator(200, 0);
     data.forEach(function(d) {
       context.fillStyle = colorScale(d.label);
-      context.fillRect(w * (d.x + 6) / 12, h * (d.y + 6) / 12, 4, 4);
+      context.fillRect(w * (d.x + 6) / 12, h - (h * (d.y + 6) / 12), 4, 4);
     });
     d3.select(canvas.parentNode).style("display", null);
   }


### PR DESCRIPTION
The thumbnails are upside-down because of the position of the origin.