### PR TITLE
 Continuous update of weights in Link cards

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -779,7 +779,7 @@ function drawLink(
   container.append("path")
     .attr("d", diagonal(datum, 0))
     .attr("class", "link-hover")
-    .on("mouseenter", function() {
+    .on("mousemove", function() {
       updateHoverCard(HoverType.WEIGHT, input, d3.mouse(this));
     }).on("mouseleave", function() {
       updateHoverCard(null);


### PR DESCRIPTION
solves #198 

Changed `mouseenter` to `mousemove` in `playground.ts` -> `Line 782`

Thoughts : I think this is an efficient way of handling the problem

